### PR TITLE
Fix CLI invocation and env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ This repository is under active research development. See our [Research Document
 Secrets such as API keys are no longer loaded from `config/config.json`. Instead
 the project reads configuration values from environment variables. You can store
 these secrets using the [Codex CLI](https://github.com/openai/codex) and set the
-`envKey` field in `~/.codex/config.json` to match the variable names used by the
-code (e.g. `OPEN_AI_KEY`, `NEWSAPI_KEY`).
+`envKey` field in `~/.codex/config.json` to match the lowercase variable names
+used by the code (e.g. `open_ai_key`, `newsapi_key`).
 
 ## Research Goals
 

--- a/docs/README_SENTIMENT_AGENT.md
+++ b/docs/README_SENTIMENT_AGENT.md
@@ -92,12 +92,12 @@ The CLI exposes several tools for data retrieval:
 
 Environment variables are now used instead of `config/config.json`. Secrets can
 be managed with the [Codex](https://github.com/openai/codex) CLI by storing them
-and setting `envKey` fields to match the variable names below:
+and setting `envKey` fields to match the lowercase variable names below:
 
-- `OPEN_AI_KEY`
-- `NEWSAPI_KEY`
-- `ALPHA_VANTAGE_KEY`
-- `FINNHUB_KEY`
+- `open_ai_key`
+- `newsapi_key`
+- `alpha_vantage_key`
+- `finnhub_key`
 
 > NOTE: API KEYS ARE NOT PRESENT AT THE REPO LEVEL SEE LOCAL SYSTEM. if **missing** API KEYS, SELF PROCUREMENT ***WILL*** BE REQUIRED.
 

--- a/quant_direct.py
+++ b/quant_direct.py
@@ -13,7 +13,11 @@ async def process_with_agent(prompt: str, agent: QuantitativeAgent):
     Handles both synchronous and coroutine returns (process_with_tools_async).
     """
     try:
-        result = agent.generate_reply([prompt])
+        # generate_reply expects a list of message dicts similar to
+        # AutoGen's conversation format. Provide the prompt as a single
+        # user message.
+        messages = [{"role": "user", "content": prompt}]
+        result = agent.generate_reply(messages)
         if asyncio.iscoroutine(result):
             response = await result
             return response


### PR DESCRIPTION
## Summary
- send user prompt in AutoGen message format when invoking QuantitativeAgent
- document lower‑case environment variable names in README files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6848506dfc948323979bff8e48b9700b