### PR TITLE
Standardize API key environment variable names

### DIFF
--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -50,7 +50,7 @@ import os
 
 # Read configuration from environment variables
 model_name = os.getenv("open_model")  # e.g. "gpt-4o-mini"
-open_ai_key = os.getenv("open_ai_key")
+open_ai_key = os.getenv("OPEN_AI_KEY")
 
 # Fallback map for tool execution
 TOOL_FUNCTION_MAP = {

--- a/src/tools/data_sources/government/FRED_data_tool.py
+++ b/src/tools/data_sources/government/FRED_data_tool.py
@@ -65,7 +65,7 @@ class FREDDataTool:
 
         # Load API key from environment if not provided
         if api_key is None:
-            api_key = os.getenv("fredapi")
+            api_key = os.getenv("FREDAPI")
 
             if not api_key:
                 self.logger.error("No FRED API key provided in environment")

--- a/src/tools/data_sources/market/alpha_vantage_market.py
+++ b/src/tools/data_sources/market/alpha_vantage_market.py
@@ -26,7 +26,7 @@ class AlphaVantageMarketTool:
 
     def __init__(self):
         # Load API key from environment
-        self.api_key = os.getenv("alpha_vantage_key")
+        self.api_key = os.getenv("ALPHA_VANTAGE_KEY")
 
         if not self.api_key:
             logging.warning("Alpha Vantage API key not found in config.")

--- a/src/tools/data_sources/news/alpha_vantage_news.py
+++ b/src/tools/data_sources/news/alpha_vantage_news.py
@@ -24,7 +24,7 @@ class AlphaVantageNewsTool:
 
     def __init__(self):
         # Load API key from environment
-        self.api_key = os.getenv("alpha_vantage_key")
+        self.api_key = os.getenv("ALPHA_VANTAGE_KEY")
 
         if not self.api_key:
             logging.warning("Alpha Vantage API key not found in config.")

--- a/src/tools/data_sources/news/finnhub_tool.py
+++ b/src/tools/data_sources/news/finnhub_tool.py
@@ -52,7 +52,7 @@ class FinnHubTool:
 
         # Load API key from environment if not provided
         if api_key is None:
-            api_key = os.getenv("finnhub_key")
+            api_key = os.getenv("FINNHUB_KEY")
 
             if not api_key:
                 self.logger.error("No Finnhub API key provided in environment")

--- a/src/tools/data_sources/news/news_headline_tool.py
+++ b/src/tools/data_sources/news/news_headline_tool.py
@@ -13,7 +13,7 @@ class NewsHeadlineTool:
 
     def __init__(self, source="newsapi"):
         # Load configuration and API key from environment
-        self.api_key = os.getenv("newsapi_key")
+        self.api_key = os.getenv("NEWSAPI_KEY")
         self.source = source
 
         # Initialize sentiment analyzer


### PR DESCRIPTION
## Summary
- ensure API key environment variable names use all caps
- update BaseAgent and data source tools to use new names

## Testing
- `pip install -q pandas`
- `pip install -q nltk`
- `pip install -q yfinance`
- `pip install -q sec-edgar-downloader`
- `pip install -q fredapi`
- `pip install -e .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src.core.memory')*

------
https://chatgpt.com/codex/tasks/task_e_6848aaabc5a883239c896b9024fd9102