### PR TITLE
Implement expanded TA indicator suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ RH2MAS is a research project developing an LLM-based investment research system 
 - /docs           # Research notes
 - -/architecture  # System design documentation
 - -/research      # Research progress and findings
+- -/indicator_library.md  # Technical indicator definitions
 - /src
 - -/agents
 - -/core          # Core architecture components

--- a/docs/indicator_library.md
+++ b/docs/indicator_library.md
@@ -1,0 +1,21 @@
+# Technical Indicator Library
+
+The `indicator_library` module provides common TA indicators used by the QuantitativeAgent.
+All indicator output columns follow the pattern `INDICATOR_component`.
+
+| Indicator | Columns Produced |
+|-----------|-----------------|
+| EMA(span) | `EMA_<span>` |
+| SMA(window) | `SMA_<window>` |
+| RSI(period) | `RSI_<period>` |
+| ATR(period) | `ATR_<period>` |
+| Supertrend | `ST` |
+| Anchored VWAP | `AVWAP` |
+| MACD | `MACD_line`, `MACD_signal`, `MACD_hist` |
+| Bollinger Bands | `BB_upper`, `BB_middle`, `BB_lower` |
+| ADX + DI± | `ADX`, `DI_pos`, `DI_neg` |
+| Ichimoku Cloud | `Ichimoku_baseline`, `Ichimoku_span_a`, `Ichimoku_span_b` |
+| Stochastic RSI | `StochRSI`, `StochRSI_K`, `StochRSI_D` |
+| CCI | `CCI` |
+
+These names are returned in the QuantitativeAgent's `latest_row` dictionary so downstream tools can rely on a consistent schema.

--- a/src/agents/quantitative_agent.py
+++ b/src/agents/quantitative_agent.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 # 3rd-party libs
 import pandas as pd
+
 # TODO numpy usage coming
 import numpy as np
 
@@ -13,12 +14,28 @@ import numpy as np
 from src.agents.base_agent import BaseAgent
 from src.tools.tools import QUANTITATIVE_AGENT, get_tools_for_agent
 from src.tools.processors.indicator_library import (
-    sma, ema, rsi, atr, supertrend, avwap
+    sma,
+    ema,
+    rsi,
+    atr,
+    supertrend,
+    avwap,
+    macd,
+    bollinger_bands,
+    adx,
+    ichimoku,
+    stochrsi,
+    cci,
 )
-from src.tools.date_utils import process_date_param, get_processed_date_range, get_default_date_range
+from src.tools.processors.data_normalizer import standardize_indicator_columns
+from src.tools.date_utils import (
+    process_date_param,
+    get_processed_date_range,
+    get_default_date_range,
+)
 
 QUANT_LLM_CONFIG = {
-    "temperature": 0.15,      # deterministic outputs
+    "temperature": 0.15,  # deterministic outputs
     "max_tokens": 4096,
     "top_p": 0.9,
     # You can set frequency_penalty / presence_penalty if hallucinations crop up
@@ -50,7 +67,6 @@ class QuantitativeAgent(BaseAgent):
         # Optional: attach a logger
         self.logger = logging.getLogger(self.__class__.__name__)
 
-
     def preprocess_message(self, message: str) -> Dict[str, Any]:
         """
         Parse financial queries to extract tickers, indicators, timeframes, and other parameters.
@@ -81,9 +97,9 @@ class QuantitativeAgent(BaseAgent):
 
         # 1. Extract ticker symbols (2-5 uppercase letters)
         ticker_patterns = [
-            r'\$([A-Z]{2,5})\b',            # With $ prefix
-            r'\bticker[:\s]+([A-Z]{2,5})\b',  # "ticker: AAPL"
-            r'\b([A-Z]{2,5})\b',            # Standard ticker format
+            r"\$([A-Z]{2,5})\b",  # With $ prefix
+            r"\bticker[:\s]+([A-Z]{2,5})\b",  # "ticker: AAPL"
+            r"\b([A-Z]{2,5})\b",  # Standard ticker format
         ]
 
         ticker = None
@@ -91,23 +107,44 @@ class QuantitativeAgent(BaseAgent):
             match = re.search(pattern, original_text)
             if match:
                 potential_ticker = match.group(1)
-                false_positives = {'USD', 'GMT', 'EST',
-                                'PST', 'API', 'HTTP', 'JSON', 'XML'}
+                false_positives = {
+                    "USD",
+                    "GMT",
+                    "EST",
+                    "PST",
+                    "API",
+                    "HTTP",
+                    "JSON",
+                    "XML",
+                }
                 if potential_ticker not in false_positives:
                     ticker = potential_ticker
                     break
 
-        parsed['ticker'] = ticker or 'SPY'  # Default to SPY
+        parsed["ticker"] = ticker or "SPY"  # Default to SPY
 
         # 2. Extract indicators with parameters (only supported: sma, ema, rsi, atr)
         indicators: List[str] = []
         indicator_patterns = {
-            'sma': r'sma\s*\(?(\d+)\)?|simple\s+moving\s+average\s*\(?(\d+)\)?|(\d+)[\s-]*day\s+sma',
-            'ema': r'ema\s*\(?(\d+)\)?|exponential\s+moving\s+average\s*\(?(\d+)\)?|(\d+)[\s-]*day\s+ema',
-            'rsi': r'rsi\s*\(?(\d+)\)?|relative\s+strength\s+index\s*\(?(\d+)\)?',
-            'atr': r'atr\s*\(?(\d+)\)?|average\s+true\s+range\s*\(?(\d+)\)?'
+            "sma": r"sma\s*\(?(\d+)\)?|simple\s+moving\s+average\s*\(?(\d+)\)?|(\d+)[\s-]*day\s+sma",
+            "ema": r"ema\s*\(?(\d+)\)?|exponential\s+moving\s+average\s*\(?(\d+)\)?|(\d+)[\s-]*day\s+ema",
+            "rsi": r"rsi\s*\(?(\d+)\)?|relative\s+strength\s+index\s*\(?(\d+)\)?",
+            "atr": r"atr\s*\(?(\d+)\)?|average\s+true\s+range\s*\(?(\d+)\)?",
+            "macd": r"macd",
+            "bollinger": r"bollinger\s*bands?|\bbb",
+            "adx": r"adx|average\s+directional",
+            "ichimoku": r"ichimoku",
+            "stochrsi": r"stoch(?:astic)?\s*rsi",
+            "cci": r"cci|commodity\s+channel\s+index",
         }
-        default_periods = {'sma': 20, 'ema': 20, 'rsi': 14, 'atr': 14}
+        default_periods = {
+            "sma": 20,
+            "ema": 20,
+            "rsi": 14,
+            "atr": 14,
+            "adx": 14,
+            "cci": 20,
+        }
 
         for indicator, pattern in indicator_patterns.items():
             for match in re.finditer(pattern, lower_text):
@@ -117,40 +154,46 @@ class QuantitativeAgent(BaseAgent):
                         period = int(group)
                         break
                 if period is None:
-                    period = default_periods[indicator]
-                indicators.append(f"{indicator}({period})")
+                    period = default_periods.get(indicator)
+                if period:
+                    indicators.append(f"{indicator}({period})")
+                else:
+                    indicators.append(indicator)
 
         # If none of those were found, add basic defaults
         if not indicators:
-            if any(word in lower_text for word in ['chart', 'technical', 'analysis', 'trend']):
-                indicators = ['sma(20)', 'rsi(14)', 'atr(14)']
-            elif any(word in lower_text for word in ['momentum', 'oscillator']):
-                indicators = ['rsi(14)', 'ema(20)']
+            if any(
+                word in lower_text
+                for word in ["chart", "technical", "analysis", "trend"]
+            ):
+                indicators = ["sma(20)", "rsi(14)", "atr(14)"]
+            elif any(word in lower_text for word in ["momentum", "oscillator"]):
+                indicators = ["rsi(14)", "ema(20)"]
             else:
-                indicators = ['sma(20)', 'rsi(14)']
+                indicators = ["sma(20)", "rsi(14)"]
 
-        parsed['indicators'] = indicators
+        parsed["indicators"] = indicators
 
         # 3. Extract timeframe/interval
         interval_patterns = {
-            '1m': r'\b1\s*(?:min|minute|m)\b',
-            '5m': r'\b5\s*(?:min|minute|m)\b',
-            '15m': r'\b15\s*(?:min|minute|m)\b',
-            '30m': r'\b30\s*(?:min|minute|m)\b',
-            '1h': r'\b1\s*(?:hour|hr|h)\b',
-            '4h': r'\b4\s*(?:hour|hr|h)\b',
-            '1d': r'\b(?:1\s*)?(?:day|daily|d)\b',
-            '1w': r'\b(?:1\s*)?(?:week|weekly|w)\b',
-            '1M': r'\b(?:1\s*)?(?:month|monthly|m)\b'
+            "1m": r"\b1\s*(?:min|minute|m)\b",
+            "5m": r"\b5\s*(?:min|minute|m)\b",
+            "15m": r"\b15\s*(?:min|minute|m)\b",
+            "30m": r"\b30\s*(?:min|minute|m)\b",
+            "1h": r"\b1\s*(?:hour|hr|h)\b",
+            "4h": r"\b4\s*(?:hour|hr|h)\b",
+            "1d": r"\b(?:1\s*)?(?:day|daily|d)\b",
+            "1w": r"\b(?:1\s*)?(?:week|weekly|w)\b",
+            "1M": r"\b(?:1\s*)?(?:month|monthly|m)\b",
         }
 
-        interval = '1h'  # Default
+        interval = "1h"  # Default
         for tf, pattern in interval_patterns.items():
             if re.search(pattern, lower_text):
                 interval = tf
                 break
 
-        parsed['interval'] = interval
+        parsed["interval"] = interval
 
         # 4. Extract raw date strings (we’ll normalize next)
         start_date = None
@@ -159,46 +202,46 @@ class QuantitativeAgent(BaseAgent):
 
         # 4a. Look for relative phrases (run on lower_text)
         time_patterns = {
-            'days': r'(?:last|past)\s+(\d+)\s+days?|(\d+)\s+days?\s+ago',
-            'weeks': r'(?:last|past)\s+(\d+)\s+weeks?|(\d+)\s+weeks?\s+ago',
-            'months': r'(?:last|past)\s+(\d+)\s+months?|(\d+)\s+months?\s+ago',
-            'years': r'(?:last|past)\s+(\d+)\s+years?|(\d+)\s+years?\s+ago',
-            'ytd': r'\bytd\b|year\s+to\s+date'
+            "days": r"(?:last|past)\s+(\d+)\s+days?|(\d+)\s+days?\s+ago",
+            "weeks": r"(?:last|past)\s+(\d+)\s+weeks?|(\d+)\s+weeks?\s+ago",
+            "months": r"(?:last|past)\s+(\d+)\s+months?|(\d+)\s+months?\s+ago",
+            "years": r"(?:last|past)\s+(\d+)\s+years?|(\d+)\s+years?\s+ago",
+            "ytd": r"\bytd\b|year\s+to\s+date",
         }
 
         for period_type, pattern in time_patterns.items():
             match = re.search(pattern, lower_text)
             if match:
-                if period_type == 'ytd':
-                    start_date = 'ytd'
-                    end_date = 'today'
+                if period_type == "ytd":
+                    start_date = "ytd"
+                    end_date = "today"
                     break
                 else:
                     number = match.group(1) or match.group(2)
                     if number:
                         number = int(number)
-                        if period_type == 'days':
+                        if period_type == "days":
                             start_date = f"-{number}d"
                             lookback_days = number
-                        elif period_type == 'weeks':
+                        elif period_type == "weeks":
                             start_date = f"-{number}w"
                             lookback_days = number * 7
-                        elif period_type == 'months':
+                        elif period_type == "months":
                             start_date = f"-{number}m"
                             lookback_days = number * 30  # Approximate
-                        elif period_type == 'years':
+                        elif period_type == "years":
                             start_date = f"-{number}y"
                             lookback_days = number * 365  # Approximate
-                        end_date = 'today'
+                        end_date = "today"
                         break
 
         # 4b. Look for absolute‐date patterns (run on original_text)
         absolute_date_patterns = [
-            r'from\s+(\d{4}-\d{1,2}-\d{1,2})\s+to\s+(\d{4}-\d{1,2}-\d{1,2})',
-            r'between\s+(\d{4}-\d{1,2}-\d{1,2})\s+and\s+(\d{4}-\d{1,2}-\d{1,2})',
-            r'since\s+(\d{4}-\d{1,2}-\d{1,2})',
-            r'after\s+(\d{4}-\d{1,2}-\d{1,2})',
-            r'(\d{1,2})/(\d{1,2})/(\d{4})'  # MM/DD/YYYY
+            r"from\s+(\d{4}-\d{1,2}-\d{1,2})\s+to\s+(\d{4}-\d{1,2}-\d{1,2})",
+            r"between\s+(\d{4}-\d{1,2}-\d{1,2})\s+and\s+(\d{4}-\d{1,2}-\d{1,2})",
+            r"since\s+(\d{4}-\d{1,2}-\d{1,2})",
+            r"after\s+(\d{4}-\d{1,2}-\d{1,2})",
+            r"(\d{1,2})/(\d{1,2})/(\d{4})",  # MM/DD/YYYY
         ]
         if not (start_date and end_date):
             for pattern in absolute_date_patterns:
@@ -206,109 +249,131 @@ class QuantitativeAgent(BaseAgent):
                 if not match:
                     continue
 
-                if pattern.startswith(r'from'):
+                if pattern.startswith(r"from"):
                     start_date = match.group(1)
                     end_date = match.group(2)
 
-                elif pattern.startswith(r'between'):
+                elif pattern.startswith(r"between"):
                     start_date = match.group(1)
                     end_date = match.group(2)
 
-                elif pattern.startswith(r'since'):
+                elif pattern.startswith(r"since"):
                     start_date = match.group(1)
-                    end_date = 'today'
+                    end_date = "today"
 
-                elif pattern.startswith(r'after'):
+                elif pattern.startswith(r"after"):
                     start_date = match.group(1)
-                    end_date = 'today'
+                    end_date = "today"
 
                 else:  # MM/DD/YYYY
                     month, day, year = match.groups()
                     start_date = f"{year}-{month.zfill(2)}-{day.zfill(2)}"
-                    end_date = 'today'
+                    end_date = "today"
 
                 break  # stop on the first absolute-date match
 
         # 4c. If still no explicit start/end, set defaults based on interval
         if not start_date and not end_date:
             default_lookbacks = {
-                '1m': 1, '5m': 3, '15m': 7, '30m': 14,
-                '1h': 30, '4h': 90, '1d': 200, '1w': 365, '1M': 1825
+                "1m": 1,
+                "5m": 3,
+                "15m": 7,
+                "30m": 14,
+                "1h": 30,
+                "4h": 90,
+                "1d": 200,
+                "1w": 365,
+                "1M": 1825,
             }
             lookback_days = default_lookbacks.get(interval, 90)
             start_date = f"-{lookback_days}d"
-            end_date = 'today'
+            end_date = "today"
 
         # 4d. Now normalize via get_processed_date_range(...)
         #     (internally calls process_date_param(...) or get_default_date_range)
         processed_start, processed_end = get_processed_date_range(
             start_date=start_date,
             end_date=end_date,
-            default_days_back=lookback_days or 90
+            default_days_back=lookback_days or 90,
         )
-        parsed['start_date'] = processed_start
-        parsed['end_date'] = processed_end
+        parsed["start_date"] = processed_start
+        parsed["end_date"] = processed_end
 
         # 4e. Compute lookback string if not already set
         if lookback_days:
-            parsed['lookback'] = f"{lookback_days}d"
+            parsed["lookback"] = f"{lookback_days}d"
         else:
             try:
                 from datetime import datetime as _dt
+
                 s = _dt.strptime(processed_start, "%Y-%m-%d")
                 e = _dt.strptime(processed_end, "%Y-%m-%d")
                 days_diff = (e - s).days
-                parsed['lookback'] = f"{days_diff}d"
+                parsed["lookback"] = f"{days_diff}d"
             except Exception:
-                parsed['lookback'] = "90d"
+                parsed["lookback"] = "90d"
 
         # 5. Detect macro/economic data needs (phrase-level)
         macro_phrases = [
-            'yield curve', 'spread', 'recession', 'inflation',
-            'gdp', 'unemployment', 'fed', 'interest rates',
-            'treasury', 'bonds', 'economic', 'cpi', 'ppi', 'fomc',
-            'federal reserve'
+            "yield curve",
+            "spread",
+            "recession",
+            "inflation",
+            "gdp",
+            "unemployment",
+            "fed",
+            "interest rates",
+            "treasury",
+            "bonds",
+            "economic",
+            "cpi",
+            "ppi",
+            "fomc",
+            "federal reserve",
         ]
         needs_macro = any(phrase in lower_text for phrase in macro_phrases)
-        parsed['needs_macro'] = needs_macro
+        parsed["needs_macro"] = needs_macro
 
         # 6. Extract chart_type for LLM to describe (no actual rendering done)
-        if any(word in lower_text for word in ['candlestick', 'candle', 'ohlc']):
-            chart_type = 'candlestick'
-        elif any(word in lower_text for word in ['line', 'linear']):
-            chart_type = 'line'
+        if any(word in lower_text for word in ["candlestick", "candle", "ohlc"]):
+            chart_type = "candlestick"
+        elif any(word in lower_text for word in ["line", "linear"]):
+            chart_type = "line"
         else:
-            chart_type = 'candlestick'
-        parsed['chart_type'] = chart_type
+            chart_type = "candlestick"
+        parsed["chart_type"] = chart_type
 
         # 7. Extract analysis_types for LLM to frame its narrative
         analysis_keywords = {
-            'support_resistance': ['support', 'resistance', 'levels'],
-            'trend_analysis': ['trend', 'direction', 'momentum'],
-            'volatility': ['volatility', 'vol', 'variance'],
-            'correlation': ['correlation', 'corr', 'relationship'],
-            'comparison': ['compare', 'vs', 'versus', 'against']
+            "support_resistance": ["support", "resistance", "levels"],
+            "trend_analysis": ["trend", "direction", "momentum"],
+            "volatility": ["volatility", "vol", "variance"],
+            "correlation": ["correlation", "corr", "relationship"],
+            "comparison": ["compare", "vs", "versus", "against"],
         }
         analysis_types: List[str] = []
         for a_type, keywords in analysis_keywords.items():
             if any(keyword in lower_text for keyword in keywords):
                 analysis_types.append(a_type)
-        parsed['analysis_types'] = analysis_types or ['basic']
+        parsed["analysis_types"] = analysis_types or ["basic"]
 
         # 8. Extract comparison_tickers (case-insensitive)
         comparison_tickers: List[str] = []
         vs_patterns = [
-            r'vs\s+([A-Za-z]{2,5})',
-            r'versus\s+([A-Za-z]{2,5})',
-            r'against\s+([A-Za-z]{2,5})',
-            r'compare.*?([A-Za-z]{2,5})'
+            r"vs\s+([A-Za-z]{2,5})",
+            r"versus\s+([A-Za-z]{2,5})",
+            r"against\s+([A-Za-z]{2,5})",
+            r"compare.*?([A-Za-z]{2,5})",
         ]
         for pattern in vs_patterns:
             for match in re.finditer(pattern, original_text, flags=re.IGNORECASE):
                 comp_ticker = match.group(1).upper()
-                if comp_ticker != parsed['ticker'] and comp_ticker not in comparison_tickers:
+                if (
+                    comp_ticker != parsed["ticker"]
+                    and comp_ticker not in comparison_tickers
+                ):
                     comparison_tickers.append(comp_ticker)
-        parsed['comparison_tickers'] = comparison_tickers
+        parsed["comparison_tickers"] = comparison_tickers
 
         return parsed
 
@@ -323,9 +388,7 @@ class QuantitativeAgent(BaseAgent):
             snippets.append(f"Focus ticker: {query['ticker']}")
 
         if query.get("indicators"):
-            snippets.append(
-                "Requested indicators: " + ", ".join(query["indicators"])
-            )
+            snippets.append("Requested indicators: " + ", ".join(query["indicators"]))
 
         snippets.append(
             "Available quantitative tools: fetch_market_data, fetch_yahoo_data, "
@@ -335,10 +398,7 @@ class QuantitativeAgent(BaseAgent):
         return "\n".join(snippets)
 
     def process_tool_result(
-        self,
-        tool_name: str,
-        result: Any,
-        tool_args: Dict[str, Any]
+        self, tool_name: str, result: Any, tool_args: Dict[str, Any]
     ) -> Any:
         """
         Convert raw DataFrames into lightweight dict summaries and/or
@@ -368,20 +428,41 @@ class QuantitativeAgent(BaseAgent):
                 df["EMA50"] = ema(df["Close"], 50)
                 df["RSI14"] = rsi(df["Close"], 14)
                 df["ATR14"] = atr(df["High"], df["Low"], df["Close"], 14)
-                df["ST"] = supertrend(df["High"], df["Low"], df["Close"],
-                                      period=10, mult=3)
+                df["ST"] = supertrend(
+                    df["High"], df["Low"], df["Close"], period=10, mult=3
+                )
+
+                req = [ind.split("(")[0] for ind in tool_args.get("indicators", [])]
+
+                if "macd" in req:
+                    df = pd.concat([df, macd(df["Close"])], axis=1)
+                if "bollinger" in req:
+                    df = pd.concat([df, bollinger_bands(df["Close"])], axis=1)
+                if "adx" in req:
+                    df = pd.concat(
+                        [df, adx(df["High"], df["Low"], df["Close"])], axis=1
+                    )
+                if "ichimoku" in req:
+                    df = pd.concat(
+                        [df, ichimoku(df["High"], df["Low"], df["Close"])], axis=1
+                    )
+                if "stochrsi" in req:
+                    df = pd.concat([df, stochrsi(df["Close"])], axis=1)
+                if "cci" in req:
+                    df["CCI"] = cci(df["High"], df["Low"], df["Close"])
 
                 # ------- optional AVWAP (needs volume + explicit ask) --------
-                if (
-                    "Volume" in df.columns
-                    and "avwap" in tool_args.get("indicators", [])
+                if "Volume" in df.columns and "avwap" in tool_args.get(
+                    "indicators", []
                 ):
                     df["AVWAP"] = avwap(df["Close"], df["Volume"])
 
+                df = standardize_indicator_columns(df)
+
                 # ------- Go/NoGo one-liner -----------------------------------
                 go_flag = (
-                    (df["Close"].iloc[-1] > df["EMA50"].iloc[-1])
-                    and (df["RSI14"].iloc[-1] > 55)
+                    (df["Close"].iloc[-1] > df["EMA_50"].iloc[-1])
+                    and (df["RSI_14"].iloc[-1] > 55)
                     and (df["Close"].iloc[-1] > df["ST"].iloc[-1])
                 )
 
@@ -398,7 +479,7 @@ class QuantitativeAgent(BaseAgent):
     def generate_reply(self, messages, context=None):
         """
         Primary entry-point required by AutoGen-assistant agents.
-        NOTE: once we bolt in the memory system, BaseAgent.process_with_tools() 
+        NOTE: once we bolt in the memory system, BaseAgent.process_with_tools()
             can merge context (e.g. prior trades, user preferences) into the system prompt.
         """
         # --------------- Extract last user message -------------------------

--- a/src/tools/processors/data_normalizer.py
+++ b/src/tools/processors/data_normalizer.py
@@ -5,240 +5,267 @@ Data normalization utilities for standardizing data from different sources into 
 import pandas as pd
 from datetime import datetime
 from typing import Optional, Dict, Any, Union
+import re
 
 
 # Define common schemas
 
 # Schema for news/text data
 NEWS_SCHEMA = {
-    'timestamp': 'datetime64[ns]',     # When the article/data was published
-    'title': 'str',                    # Article title or headline
-    'content': 'str',                  # Main content text
-    'source': 'str',                   # Source of the content (e.g., "Bloomberg", "Reuters")
-    'url': 'str',                      # URL to the original content
-    'sentiment_score': 'float',        # Pre-calculated sentiment score if available
-    'keywords': 'object',              # List of keywords or tags
-    'category': 'str'                  # News category (e.g., "Economy", "Markets", "Technology")
+    "timestamp": "datetime64[ns]",  # When the article/data was published
+    "title": "str",  # Article title or headline
+    "content": "str",  # Main content text
+    "source": "str",  # Source of the content (e.g., "Bloomberg", "Reuters")
+    "url": "str",  # URL to the original content
+    "sentiment_score": "float",  # Pre-calculated sentiment score if available
+    "keywords": "object",  # List of keywords or tags
+    "category": "str",  # News category (e.g., "Economy", "Markets", "Technology")
 }
 
 # Schema for market data
 MARKET_SCHEMA = {
-    'timestamp': 'datetime64[ns]',     # Date/time of the data point
-    'symbol': 'str',                   # Stock/asset symbol
-    'open': 'float',                   # Opening price
-    'high': 'float',                   # High price
-    'low': 'float',                    # Low price
-    'close': 'float',                  # Closing price
-    'volume': 'float',                 # Trading volume
-    'source': 'str'                    # Data source (e.g., "Yahoo", "AlphaVantage")
+    "timestamp": "datetime64[ns]",  # Date/time of the data point
+    "symbol": "str",  # Stock/asset symbol
+    "open": "float",  # Opening price
+    "high": "float",  # High price
+    "low": "float",  # Low price
+    "close": "float",  # Closing price
+    "volume": "float",  # Trading volume
+    "source": "str",  # Data source (e.g., "Yahoo", "AlphaVantage")
 }
 
 # Schema for economic data (from FRED and similar sources)
 ECONOMIC_SCHEMA = {
-    'timestamp': 'datetime64[ns]',     # Date/time of the data point
-    'indicator': 'str',                # Economic indicator name/code (e.g., "GDP", "UNRATE")
-    'value': 'float',                  # Value of the indicator
-    'units': 'str',                    # Units of measurement (e.g., "Percent", "Billions of Dollars")
-    'frequency': 'str',                # Data frequency (e.g., "Monthly", "Quarterly")
-    'title': 'str',                    # Full title/description of the indicator
-    'source': 'str'                    # Data source (e.g., "FRED", "BEA")
+    "timestamp": "datetime64[ns]",  # Date/time of the data point
+    "indicator": "str",  # Economic indicator name/code (e.g., "GDP", "UNRATE")
+    "value": "float",  # Value of the indicator
+    "units": "str",  # Units of measurement (e.g., "Percent", "Billions of Dollars")
+    "frequency": "str",  # Data frequency (e.g., "Monthly", "Quarterly")
+    "title": "str",  # Full title/description of the indicator
+    "source": "str",  # Data source (e.g., "FRED", "BEA")
 }
 
 
 def create_empty_news_df() -> pd.DataFrame:
     """Create an empty DataFrame with the standard news schema."""
-    df = pd.DataFrame({col: pd.Series(dtype=dtype) for col, dtype in NEWS_SCHEMA.items()})
+    df = pd.DataFrame(
+        {col: pd.Series(dtype=dtype) for col, dtype in NEWS_SCHEMA.items()}
+    )
     return df
 
 
 def create_empty_market_df() -> pd.DataFrame:
     """Create an empty DataFrame with the standard market schema."""
-    df = pd.DataFrame({col: pd.Series(dtype=dtype) for col, dtype in MARKET_SCHEMA.items()})
+    df = pd.DataFrame(
+        {col: pd.Series(dtype=dtype) for col, dtype in MARKET_SCHEMA.items()}
+    )
     return df
 
 
 def create_empty_economic_df() -> pd.DataFrame:
     """Create an empty DataFrame with the standard economic data schema."""
-    df = pd.DataFrame({col: pd.Series(dtype=dtype) for col, dtype in ECONOMIC_SCHEMA.items()})
+    df = pd.DataFrame(
+        {col: pd.Series(dtype=dtype) for col, dtype in ECONOMIC_SCHEMA.items()}
+    )
+    return df
+
+
+def standardize_indicator_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Rename indicator columns to `INDICATOR_param` format."""
+    rename_map = {}
+    pattern = re.compile(r"([A-Za-z]+)(\d+)$")
+    for col in df.columns:
+        m = pattern.match(col)
+        if m:
+            rename_map[col] = f"{m.group(1).upper()}_{m.group(2)}"
+    if rename_map:
+        df = df.rename(columns=rename_map)
     return df
 
 
 def normalize_newsapi_data(raw_df: pd.DataFrame) -> pd.DataFrame:
     """
     Normalize data from NewsHeadlineTool to the common news schema.
-    
+
     Args:
         raw_df: Raw DataFrame returned by NewsHeadlineTool
-        
+
     Returns:
         Normalized DataFrame following the common schema
     """
     if raw_df.empty:
         return create_empty_news_df()
-    
+
     normalized_df = pd.DataFrame()
-    
+
     # Map columns to standard schema
-    normalized_df['timestamp'] = raw_df['Timestamp']
-    normalized_df['title'] = raw_df['Headline']
-    normalized_df['content'] = raw_df['Content']
-    normalized_df['source'] = raw_df['Source']
-    normalized_df['url'] = raw_df['URL']
-    normalized_df['sentiment_score'] = raw_df['Sentiment Score']
-    
+    normalized_df["timestamp"] = raw_df["Timestamp"]
+    normalized_df["title"] = raw_df["Headline"]
+    normalized_df["content"] = raw_df["Content"]
+    normalized_df["source"] = raw_df["Source"]
+    normalized_df["url"] = raw_df["URL"]
+    normalized_df["sentiment_score"] = raw_df["Sentiment Score"]
+
     # Add empty columns for missing fields
-    normalized_df['keywords'] = None
-    normalized_df['category'] = 'General'  # Default category
-    
+    normalized_df["keywords"] = None
+    normalized_df["category"] = "General"  # Default category
+
     return normalized_df
 
 
 def normalize_finnhub_data(raw_data: list) -> pd.DataFrame:
     """
     Normalize data from FinnHubTool to the common news schema.
-    
+
     Args:
         raw_data: Raw list of article dictionaries returned by FinnHubTool
-        
+
     Returns:
         Normalized DataFrame following the common schema
     """
     if not raw_data:
         return create_empty_news_df()
-    
+
     normalized_data = []
-    
+
     for article in raw_data:
         # Extract fields with appropriate fallbacks
-        timestamp = article.get('datetime', None)
+        timestamp = article.get("datetime", None)
         if timestamp:
             # Convert Unix timestamp to datetime if needed
             if isinstance(timestamp, int):
                 timestamp = datetime.fromtimestamp(timestamp)
-                
+
         entry = {
-            'timestamp': timestamp,
-            'title': article.get('headline', article.get('title', '')),
-            'content': article.get('summary', article.get('description', '')),
-            'source': article.get('source', ''),
-            'url': article.get('url', ''),
-            'sentiment_score': None,  # Finnhub doesn't provide sentiment scores directly
-            'keywords': article.get('related', article.get('category', '').split(',')),
-            'category': article.get('category', 'General')
+            "timestamp": timestamp,
+            "title": article.get("headline", article.get("title", "")),
+            "content": article.get("summary", article.get("description", "")),
+            "source": article.get("source", ""),
+            "url": article.get("url", ""),
+            "sentiment_score": None,  # Finnhub doesn't provide sentiment scores directly
+            "keywords": article.get("related", article.get("category", "").split(",")),
+            "category": article.get("category", "General"),
         }
         normalized_data.append(entry)
-    
+
     return pd.DataFrame(normalized_data)
 
 
 def normalize_yahoo_finance_data(raw_df: pd.DataFrame, symbol: str) -> pd.DataFrame:
     """
     Normalize data from YahooFinanceTool to the common market schema.
-    
+
     Args:
         raw_df: Raw DataFrame returned by YahooFinanceTool
         symbol: The stock symbol for the data
-        
+
     Returns:
         Normalized DataFrame following the common market schema
     """
     if raw_df.empty:
         return create_empty_market_df()
-    
+
     # Create new DataFrame with normalized schema
     normalized_df = pd.DataFrame()
-    
+
     # Map columns to standard schema
-    normalized_df['timestamp'] = raw_df.index  # Yahoo uses DatetimeIndex
-    normalized_df['symbol'] = symbol
-    normalized_df['open'] = raw_df['Open']
-    normalized_df['high'] = raw_df['High']
-    normalized_df['low'] = raw_df['Low']
-    normalized_df['close'] = raw_df['Close']
-    normalized_df['volume'] = raw_df['Volume']
-    normalized_df['source'] = 'Yahoo Finance'
-    
+    normalized_df["timestamp"] = raw_df.index  # Yahoo uses DatetimeIndex
+    normalized_df["symbol"] = symbol
+    normalized_df["open"] = raw_df["Open"]
+    normalized_df["high"] = raw_df["High"]
+    normalized_df["low"] = raw_df["Low"]
+    normalized_df["close"] = raw_df["Close"]
+    normalized_df["volume"] = raw_df["Volume"]
+    normalized_df["source"] = "Yahoo Finance"
+
     return normalized_df
 
 
 def normalize_alpha_vantage_data(raw_df: pd.DataFrame, symbol: str) -> pd.DataFrame:
     """
     Normalize data from AlphaVantageTool to the common market schema.
-    
+
     Args:
         raw_df: Raw DataFrame returned by AlphaVantageTool
         symbol: The stock symbol for the data
-        
+
     Returns:
         Normalized DataFrame following the common market schema
     """
     if raw_df.empty:
         return create_empty_market_df()
-    
+
     normalized_df = pd.DataFrame()
-    
+
     # Check column names since Alpha Vantage might use different column names
     # based on the specific API endpoint used
-    
+
     # Time series data typically has format:
     # timestamp, open, high, low, close, volume (may be capitalized)
-    if '1. open' in raw_df.columns:
+    if "1. open" in raw_df.columns:
         # Map Alpha Vantage's numbered column format
         column_map = {
-            '1. open': 'open',
-            '2. high': 'high',
-            '3. low': 'low',
-            '4. close': 'close',
-            '5. volume': 'volume'
+            "1. open": "open",
+            "2. high": "high",
+            "3. low": "low",
+            "4. close": "close",
+            "5. volume": "volume",
         }
-        
+
         for av_col, norm_col in column_map.items():
             if av_col in raw_df.columns:
                 normalized_df[norm_col] = raw_df[av_col]
-                
+
         # Alpha Vantage typically uses index as timestamp
-        normalized_df['timestamp'] = raw_df.index
-        
-    elif 'open' in raw_df.columns or 'Open' in raw_df.columns:
+        normalized_df["timestamp"] = raw_df.index
+
+    elif "open" in raw_df.columns or "Open" in raw_df.columns:
         # Handle more standard column names
         col_mapping = {
-            'open': 'open', 'Open': 'open',
-            'high': 'high', 'High': 'high',
-            'low': 'low', 'Low': 'low',
-            'close': 'close', 'Close': 'close',
-            'volume': 'volume', 'Volume': 'volume',
+            "open": "open",
+            "Open": "open",
+            "high": "high",
+            "High": "high",
+            "low": "low",
+            "Low": "low",
+            "close": "close",
+            "Close": "close",
+            "volume": "volume",
+            "Volume": "volume",
         }
-        
+
         for raw_col, norm_col in col_mapping.items():
             if raw_col in raw_df.columns:
                 normalized_df[norm_col] = raw_df[raw_col]
-                
+
         # Set timestamp from index if needed
-        if 'timestamp' not in normalized_df and 'date' not in raw_df.columns:
-            normalized_df['timestamp'] = raw_df.index
-        elif 'date' in raw_df.columns:
-            normalized_df['timestamp'] = raw_df['date']
-    
+        if "timestamp" not in normalized_df and "date" not in raw_df.columns:
+            normalized_df["timestamp"] = raw_df.index
+        elif "date" in raw_df.columns:
+            normalized_df["timestamp"] = raw_df["date"]
+
     # Add symbol and source if not present
-    normalized_df['symbol'] = symbol
-    normalized_df['source'] = 'Alpha Vantage'
-    
+    normalized_df["symbol"] = symbol
+    normalized_df["source"] = "Alpha Vantage"
+
     return normalized_df
 
 
-def normalize_market_data_for_sentiment(market_df: pd.DataFrame) -> Optional[pd.DataFrame]:
+def normalize_market_data_for_sentiment(
+    market_df: pd.DataFrame,
+) -> Optional[pd.DataFrame]:
     """
     Convert market data to a format usable for sentiment analysis or skip it.
     This function either:
     1. Returns None to indicate that market data should be skipped from sentiment pipeline
     2. Transforms market data into a news-compatible format
-    
-    For now, we'll skip market data in the sentiment pipeline since it doesn't 
+
+    For now, we'll skip market data in the sentiment pipeline since it doesn't
     contain text that can be directly analyzed for sentiment.
-    
+
     Args:
         market_df: Normalized market data DataFrame
-        
+
     Returns:
         None to indicate skipping, or a transformed DataFrame
     """
@@ -246,7 +273,9 @@ def normalize_market_data_for_sentiment(market_df: pd.DataFrame) -> Optional[pd.
     return None
 
 
-def normalize_fred_data(raw_df: pd.DataFrame, indicator: str = "Unknown") -> pd.DataFrame:
+def normalize_fred_data(
+    raw_df: pd.DataFrame, indicator: str = "Unknown"
+) -> pd.DataFrame:
     """
     Normalize data from FRED to the common economic schema.
 
@@ -263,51 +292,53 @@ def normalize_fred_data(raw_df: pd.DataFrame, indicator: str = "Unknown") -> pd.
     normalized_df = pd.DataFrame()
 
     # Check and map columns based on what's available in the raw dataframe
-    if 'Date' in raw_df.columns and 'Value' in raw_df.columns:
+    if "Date" in raw_df.columns and "Value" in raw_df.columns:
         # Standard FRED format from get_series or get_indicator
-        normalized_df['timestamp'] = pd.to_datetime(raw_df['Date'])
-        normalized_df['value'] = raw_df['Value']
+        normalized_df["timestamp"] = pd.to_datetime(raw_df["Date"])
+        normalized_df["value"] = raw_df["Value"]
 
         # Extract metadata if available
-        normalized_df['indicator'] = raw_df.get('Series ID', indicator)
-        normalized_df['title'] = raw_df.get('Title', indicator)
-        normalized_df['units'] = raw_df.get('Units', 'Unknown')
-        normalized_df['frequency'] = raw_df.get('Frequency', 'Unknown')
+        normalized_df["indicator"] = raw_df.get("Series ID", indicator)
+        normalized_df["title"] = raw_df.get("Title", indicator)
+        normalized_df["units"] = raw_df.get("Units", "Unknown")
+        normalized_df["frequency"] = raw_df.get("Frequency", "Unknown")
 
-    elif 'Date' in raw_df.columns:
+    elif "Date" in raw_df.columns:
         # This could be a yield curve or other multi-column dataset
-        normalized_df['timestamp'] = pd.to_datetime(raw_df['Date'])
+        normalized_df["timestamp"] = pd.to_datetime(raw_df["Date"])
 
         # For yield curve, we'll use a different approach - maintain original columns
         # but ensure we have the required economic schema columns
-        normalized_df['indicator'] = indicator
-        normalized_df['title'] = f"{indicator} Data"
-        normalized_df['units'] = "Percent"  # Most FRED data are in percent
-        normalized_df['frequency'] = "Daily"  # Most yield curve data are daily
+        normalized_df["indicator"] = indicator
+        normalized_df["title"] = f"{indicator} Data"
+        normalized_df["units"] = "Percent"  # Most FRED data are in percent
+        normalized_df["frequency"] = "Daily"  # Most yield curve data are daily
 
         # Handle the value column specially for yield curve
         # We'll use the 10Y as a representative value
-        if '10Y' in raw_df.columns:
-            normalized_df['value'] = raw_df['10Y']
+        if "10Y" in raw_df.columns:
+            normalized_df["value"] = raw_df["10Y"]
         else:
             # If there's no 10Y, use the first non-Date column
-            value_cols = [col for col in raw_df.columns if col != 'Date']
+            value_cols = [col for col in raw_df.columns if col != "Date"]
             if value_cols:
-                normalized_df['value'] = raw_df[value_cols[0]]
+                normalized_df["value"] = raw_df[value_cols[0]]
             else:
-                normalized_df['value'] = None
+                normalized_df["value"] = None
 
     else:
         # Try to handle other formats or return empty
         return create_empty_economic_df()
 
     # Set source to FRED
-    normalized_df['source'] = 'FRED'
+    normalized_df["source"] = "FRED"
 
     return normalized_df
 
 
-def normalize_data_for_sentiment(df: pd.DataFrame, data_type: str, **kwargs) -> Optional[pd.DataFrame]:
+def normalize_data_for_sentiment(
+    df: pd.DataFrame, data_type: str, **kwargs
+) -> Optional[pd.DataFrame]:
     """
     Main entry point for normalizing any data source for sentiment analysis.
 
@@ -322,19 +353,19 @@ def normalize_data_for_sentiment(df: pd.DataFrame, data_type: str, **kwargs) -> 
     if df.empty:
         return create_empty_news_df()
 
-    if data_type == 'news_api':
+    if data_type == "news_api":
         return normalize_newsapi_data(df)
-    elif data_type == 'finnhub':
+    elif data_type == "finnhub":
         return normalize_finnhub_data(df)
-    elif data_type == 'yahoo_finance':
+    elif data_type == "yahoo_finance":
         # Market data isn't directly usable for sentiment, so skip it
         # or we could transform it if needed
-        market_df = normalize_yahoo_finance_data(df, kwargs.get('symbol', 'UNKNOWN'))
+        market_df = normalize_yahoo_finance_data(df, kwargs.get("symbol", "UNKNOWN"))
         return normalize_market_data_for_sentiment(market_df)
-    elif data_type == 'alpha_vantage':
-        market_df = normalize_alpha_vantage_data(df, kwargs.get('symbol', 'UNKNOWN'))
+    elif data_type == "alpha_vantage":
+        market_df = normalize_alpha_vantage_data(df, kwargs.get("symbol", "UNKNOWN"))
         return normalize_market_data_for_sentiment(market_df)
-    elif data_type == 'fred':
+    elif data_type == "fred":
         # FRED economic data isn't directly usable for sentiment without transformation
         # For now, we'll just return None to skip it
         return None

--- a/src/tools/processors/indicator_library.py
+++ b/src/tools/processors/indicator_library.py
@@ -1,8 +1,22 @@
 import pandas as pd
 import numpy as np
 
+
 # Exported indicator functions
-__all__ = ["ema", "sma", "rsi", "atr", "supertrend", "avwap"]
+__all__ = [
+    "ema",
+    "sma",
+    "rsi",
+    "atr",
+    "supertrend",
+    "avwap",
+    "macd",
+    "bollinger_bands",
+    "adx",
+    "ichimoku",
+    "stochrsi",
+    "cci",
+]
 
 
 # --- Trend ---
@@ -22,19 +36,27 @@ def rsi(series: pd.Series, period: int = 14) -> pd.Series:
     roll_up = gain.rolling(period).mean()
     roll_down = loss.rolling(period).mean()
     rs = roll_up / roll_down
-    return (100 - (100/(1+rs)))
+    return 100 - (100 / (1 + rs))
 
 
 # --- Volatility ---
-def atr(high: pd.Series, low: pd.Series, close: pd.Series, period: int = 14) -> pd.Series:
-    tr = pd.concat([high - low, (high - close.shift()).abs(),
-                   (low - close.shift()).abs()], axis=1).max(axis=1)
+def atr(
+    high: pd.Series, low: pd.Series, close: pd.Series, period: int = 14
+) -> pd.Series:
+    tr = pd.concat(
+        [high - low, (high - close.shift()).abs(), (low - close.shift()).abs()], axis=1
+    ).max(axis=1)
     return tr.rolling(period).mean()
 
 
 # --- Composit trend/stop ---
-def supertrend(high: pd.Series, low: pd.Series, close: pd.Series,
-               period: int = 10, mult: float = 3.0) -> pd.Series:
+def supertrend(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    period: int = 10,
+    mult: float = 3.0,
+) -> pd.Series:
     """
     Vectorised Supertrend implementation (no explicit Python loop).
     Returns a pd.Series aligned to `close.index`.
@@ -52,10 +74,10 @@ def supertrend(high: pd.Series, low: pd.Series, close: pd.Series,
             st.iat[i] = lower.iat[i]
             continue
         # In-trend "stickiness"
-        if direction.iat[i-1]:
-            st.iat[i] = max(lower.iat[i], st.iat[i-1])
+        if direction.iat[i - 1]:
+            st.iat[i] = max(lower.iat[i], st.iat[i - 1])
         else:
-            st.iat[i] = min(upper.iat[i], st.iat[i-1])
+            st.iat[i] = min(upper.iat[i], st.iat[i - 1])
 
         # flip on close cross
         direction.iat[i] = close.iat[i] > st.iat[i]
@@ -63,9 +85,9 @@ def supertrend(high: pd.Series, low: pd.Series, close: pd.Series,
 
 
 # --- AVWAP ---
-def avwap(close: pd.Series,
-          volume: pd.Series,
-          anchor_idx: int | str | pd.Timestamp = 0) -> pd.Series:
+def avwap(
+    close: pd.Series, volume: pd.Series, anchor_idx: int | str | pd.Timestamp = 0
+) -> pd.Series:
     """
     Anchored VWAP.  `anchor_idx` can be
       • int  - positional index (0 = first row in frame),
@@ -73,11 +95,139 @@ def avwap(close: pd.Series,
       • pd.Timestamp.
     """
     if isinstance(anchor_idx, (str, pd.Timestamp)):
-        anchor_idx = close.index.get_loc(
-            pd.Timestamp(anchor_idx), method="nearest")
+        anchor_idx = close.index.get_loc(pd.Timestamp(anchor_idx), method="nearest")
     pv = (close * volume).cumsum()
     vol = volume.cumsum()
     if anchor_idx > 0:
         pv = pv - pv.iloc[anchor_idx - 1]
         vol = vol - vol.iloc[anchor_idx - 1]
-    return pv/vol
+    return pv / vol
+
+
+# --- MACD ---
+def macd(
+    series: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9
+) -> pd.DataFrame:
+    """Moving Average Convergence Divergence."""
+    ema_fast = ema(series, span=fast)
+    ema_slow = ema(series, span=slow)
+    macd_line = ema_fast - ema_slow
+    macd_signal = ema(macd_line, span=signal)
+    hist = macd_line - macd_signal
+    return pd.DataFrame(
+        {
+            "MACD_line": macd_line,
+            "MACD_signal": macd_signal,
+            "MACD_hist": hist,
+        }
+    )
+
+
+# --- Bollinger Bands ---
+def bollinger_bands(
+    series: pd.Series, window: int = 20, num_std: float = 2.0
+) -> pd.DataFrame:
+    mid = sma(series, window)
+    std = series.rolling(window=window).std()
+    upper = mid + num_std * std
+    lower = mid - num_std * std
+    return pd.DataFrame(
+        {
+            "BB_upper": upper,
+            "BB_middle": mid,
+            "BB_lower": lower,
+        }
+    )
+
+
+# --- ADX and DI +/- ---
+def adx(
+    high: pd.Series, low: pd.Series, close: pd.Series, period: int = 14
+) -> pd.DataFrame:
+    up_move = high.diff()
+    down_move = low.diff().abs()
+    plus_dm = np.where((up_move > down_move) & (up_move > 0), up_move, 0.0)
+    minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0.0)
+
+    tr = pd.concat(
+        [
+            high - low,
+            (high - close.shift()).abs(),
+            (low - close.shift()).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+
+    atr_vals = tr.rolling(window=period).sum()
+    plus_di = 100 * pd.Series(plus_dm).rolling(window=period).sum() / atr_vals
+    minus_di = 100 * pd.Series(minus_dm).rolling(window=period).sum() / atr_vals
+    dx = (abs(plus_di - minus_di) / (plus_di + minus_di)) * 100
+    adx_val = dx.rolling(window=period).mean()
+
+    return pd.DataFrame(
+        {
+            "ADX": adx_val,
+            "DI_pos": plus_di,
+            "DI_neg": minus_di,
+        }
+    )
+
+
+# --- Ichimoku Baseline & Cloud ---
+def ichimoku(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    conv_period: int = 9,
+    base_period: int = 26,
+    span_b_period: int = 52,
+) -> pd.DataFrame:
+    tenkan = (high.rolling(conv_period).max() + low.rolling(conv_period).min()) / 2
+    kijun = (high.rolling(base_period).max() + low.rolling(base_period).min()) / 2
+    span_a = ((tenkan + kijun) / 2).shift(base_period)
+    span_b = (
+        (high.rolling(span_b_period).max() + low.rolling(span_b_period).min()) / 2
+    ).shift(base_period)
+
+    return pd.DataFrame(
+        {
+            "Ichimoku_baseline": kijun,
+            "Ichimoku_span_a": span_a,
+            "Ichimoku_span_b": span_b,
+        }
+    )
+
+
+# --- Stochastic RSI ---
+def stochrsi(
+    series: pd.Series,
+    rsi_period: int = 14,
+    stoch_period: int = 14,
+    k_period: int = 3,
+    d_period: int = 3,
+) -> pd.DataFrame:
+    rsi_vals = rsi(series, rsi_period)
+    min_rsi = rsi_vals.rolling(stoch_period).min()
+    max_rsi = rsi_vals.rolling(stoch_period).max()
+    stoch = (rsi_vals - min_rsi) / (max_rsi - min_rsi)
+    k = stoch.rolling(k_period).mean()
+    d = k.rolling(d_period).mean()
+    return pd.DataFrame(
+        {
+            "StochRSI": stoch,
+            "StochRSI_K": k,
+            "StochRSI_D": d,
+        }
+    )
+
+
+# --- Commodity Channel Index ---
+def cci(
+    high: pd.Series, low: pd.Series, close: pd.Series, period: int = 20
+) -> pd.Series:
+    tp = (high + low + close) / 3
+    ma = tp.rolling(window=period).mean()
+    mad = tp.rolling(window=period).apply(
+        lambda x: np.mean(np.abs(x - x.mean())), raw=True
+    )
+    return (tp - ma) / (0.015 * mad)

--- a/tests/test_indicator_library.py
+++ b/tests/test_indicator_library.py
@@ -3,9 +3,22 @@ import pandas as pd
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from src.tools.processors.indicator_library import ema, sma, rsi, atr, supertrend, avwap
+from src.tools.processors.indicator_library import (
+    ema,
+    sma,
+    rsi,
+    atr,
+    supertrend,
+    avwap,
+    macd,
+    bollinger_bands,
+    adx,
+    ichimoku,
+    stochrsi,
+    cci,
+)
 
 
 class TestIndicatorLibrary(unittest.TestCase):
@@ -39,11 +52,14 @@ class TestIndicatorLibrary(unittest.TestCase):
         low = pd.Series([1, 1, 2])
         close = pd.Series([1.5, 2.5, 3.5])
         result = atr(high, low, close, period=2)
-        tr = pd.concat([
-            high - low,
-            (high - close.shift()).abs(),
-            (low - close.shift()).abs(),
-        ], axis=1).max(axis=1)
+        tr = pd.concat(
+            [
+                high - low,
+                (high - close.shift()).abs(),
+                (low - close.shift()).abs(),
+            ],
+            axis=1,
+        ).max(axis=1)
         expected = tr.rolling(2).mean()
         pd.testing.assert_series_equal(result, expected)
 
@@ -55,6 +71,52 @@ class TestIndicatorLibrary(unittest.TestCase):
         self.assertEqual(len(result), len(close))
         # supertrend may start with NaN due to ATR warm-up
         self.assertLessEqual(result.isna().sum(), 1)
+
+    def test_macd(self):
+        series = pd.Series(range(1, 51))
+        result = macd(series)
+        self.assertEqual(
+            list(result.columns), ["MACD_line", "MACD_signal", "MACD_hist"]
+        )
+        self.assertEqual(len(result), len(series))
+
+    def test_bollinger_bands(self):
+        series = pd.Series(range(1, 51))
+        result = bollinger_bands(series)
+        self.assertEqual(list(result.columns), ["BB_upper", "BB_middle", "BB_lower"])
+        self.assertEqual(len(result), len(series))
+
+    def test_adx(self):
+        high = pd.Series(range(2, 52))
+        low = pd.Series(range(1, 51))
+        close = pd.Series(range(1, 51))
+        result = adx(high, low, close)
+        self.assertEqual(list(result.columns), ["ADX", "DI_pos", "DI_neg"])
+        self.assertEqual(len(result), len(high))
+
+    def test_ichimoku(self):
+        high = pd.Series(range(1, 61))
+        low = pd.Series(range(1, 61))
+        close = pd.Series(range(1, 61))
+        result = ichimoku(high, low, close)
+        self.assertEqual(
+            list(result.columns),
+            ["Ichimoku_baseline", "Ichimoku_span_a", "Ichimoku_span_b"],
+        )
+        self.assertEqual(len(result), len(high))
+
+    def test_stochrsi(self):
+        series = pd.Series(range(1, 61))
+        result = stochrsi(series)
+        self.assertEqual(list(result.columns), ["StochRSI", "StochRSI_K", "StochRSI_D"])
+        self.assertEqual(len(result), len(series))
+
+    def test_cci(self):
+        high = pd.Series(range(1, 61))
+        low = pd.Series(range(1, 61))
+        close = pd.Series(range(1, 61))
+        result = cci(high, low, close)
+        self.assertEqual(len(result), len(high))
 
 
 if __name__ == "__main__":

--- a/tests/test_quant_agent.py
+++ b/tests/test_quant_agent.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from src.agents.quantitative_agent import QuantitativeAgent
+
+
+def test_preprocess_macd():
+    agent = QuantitativeAgent()
+    parsed = agent.preprocess_message("Show me MACD for TSLA")
+    names = [i.split("(")[0] for i in parsed["indicators"]]
+    assert "macd" in names
+
+
+def test_process_tool_result_macd():
+    agent = QuantitativeAgent()
+    df = pd.DataFrame(
+        {
+            "Open": [1, 2, 3, 4, 5, 6],
+            "High": [1, 2, 3, 4, 5, 6],
+            "Low": [1, 1, 2, 3, 4, 5],
+            "Close": [1, 2, 3, 4, 5, 6],
+            "Volume": [100] * 6,
+        }
+    )
+    result = agent.process_tool_result(
+        "fetch_market_data", df, {"indicators": ["macd"]}
+    )
+    assert "MACD_line" in result["latest_row"]


### PR DESCRIPTION
## Summary
- extend indicator_library with MACD, Bollinger Bands, ADX, Ichimoku, StochRSI and CCI
- parse new indicator names in QuantitativeAgent
- normalize indicator column names via standardize_indicator_columns
- compute optional indicators and expose them in `latest_row`
- document available indicators
- add unit tests for new indicators and agent parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498972289c8323af6c32337408399b