### PR TITLE
Add time-frame validation and interval alignment

### DIFF
--- a/src/agents/quantitative_agent.py
+++ b/src/agents/quantitative_agent.py
@@ -33,6 +33,7 @@ from src.tools.date_utils import (
     get_processed_date_range,
     get_default_date_range,
 )
+from src.tools.agent_utils import QueryParser
 
 QUANT_LLM_CONFIG = {
     "temperature": 0.15,  # deterministic outputs
@@ -312,6 +313,11 @@ class QuantitativeAgent(BaseAgent):
                 parsed["lookback"] = f"{days_diff}d"
             except Exception:
                 parsed["lookback"] = "90d"
+
+        # Validate interval/lookback combo against API constraints
+        QueryParser.validate_interval_lookback(
+            parsed["interval"], parsed.get("lookback", "0d")
+        )
 
         # 5. Detect macro/economic data needs (phrase-level)
         macro_phrases = [

--- a/src/tools/agent_utils.py
+++ b/src/tools/agent_utils.py
@@ -267,6 +267,42 @@ class QueryParser:
             "end_date": end_date
         }
 
+    @staticmethod
+    def _lookback_to_days(lookback: str) -> int:
+        """Convert lookback strings like '90d' or '2w' to day counts."""
+        if not lookback:
+            return 0
+        m = re.match(r"(\d+)([dwmy])", lookback)
+        if not m:
+            return 0
+        value = int(m.group(1))
+        unit = m.group(2)
+        factors = {"d": 1, "w": 7, "m": 30, "y": 365}
+        return value * factors.get(unit, 1)
+
+    @classmethod
+    def validate_interval_lookback(cls, interval: str, lookback: str) -> None:
+        """Validate that the requested lookback is allowed for the interval."""
+        limits = {
+            "1m": 60,
+            "5m": 60,
+            "15m": 60,
+            "30m": 60,
+            "1h": 730,
+            "4h": 730,
+            "1d": 3650,
+            "1w": 3650,
+            "1M": 3650,
+        }
+
+        days = cls._lookback_to_days(lookback)
+        max_days = limits.get(interval)
+        if max_days is not None and days > max_days:
+            raise ValueError(
+                f"Lookback {lookback} exceeds {max_days}d limit for {interval}. "
+                f"Try max {max_days}d for {interval} or use a larger interval like 1h."
+            )
+
 
 class DataProcessor:
     """

--- a/src/tools/date_utils.py
+++ b/src/tools/date_utils.py
@@ -157,3 +157,55 @@ def get_processed_date_range(
 
     # If neither is provided, use default range
     return get_default_date_range(default_days_back)
+
+
+def align_interval(df, interval):
+    """Resample DataFrame to match the desired interval."""
+    import pandas as pd
+
+    if df.empty:
+        return df
+
+    if not isinstance(df.index, pd.DatetimeIndex):
+        for col in ["timestamp", "date", "datetime", "Date", "Timestamp"]:
+            if col in df.columns:
+                df = df.set_index(pd.to_datetime(df[col]))
+                break
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise ValueError("DataFrame must have a datetime index or column")
+
+    freq_map = {
+        "1m": "1T",
+        "5m": "5T",
+        "15m": "15T",
+        "30m": "30T",
+        "1h": "1H",
+        "4h": "4H",
+        "1d": "1D",
+        "1w": "1W",
+        "1M": "1M",
+    }
+
+    if interval not in freq_map:
+        raise ValueError(f"Unsupported interval: {interval}")
+
+    agg = {}
+    for c in df.columns:
+        lc = c.lower()
+        if lc == "open":
+            agg[c] = "first"
+        elif lc == "high":
+            agg[c] = "max"
+        elif lc == "low":
+            agg[c] = "min"
+        elif lc == "close":
+            agg[c] = "last"
+        elif lc == "volume":
+            agg[c] = "sum"
+        else:
+            agg[c] = "last"
+
+    result = df.resample(freq_map[interval]).agg(agg)
+    result = result.ffill().dropna(how="all")
+    result.index.name = df.index.name
+    return result

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -11,7 +11,10 @@ from src.tools.date_utils import (
     get_default_date_range,
     process_date_param,
     get_processed_date_range,
+    align_interval,
 )
+from src.tools.agent_utils import QueryParser
+import pandas as pd
 
 
 class TestDateUtils(unittest.TestCase):
@@ -105,6 +108,34 @@ class TestDateUtils(unittest.TestCase):
         start, end = get_processed_date_range("-30d", "today")
         self.assertEqual(start, days_ago_30)
         self.assertEqual(end, datetime.now().strftime("%Y-%m-%d"))
+
+    def test_validate_interval_lookback_invalid(self):
+        with self.assertRaises(ValueError):
+            QueryParser.validate_interval_lookback("1m", "180d")
+
+    def test_validate_interval_lookback_valid(self):
+        QueryParser.validate_interval_lookback("1m", "60d")
+
+    def test_align_interval_downsample(self):
+        rng = pd.date_range("2024-01-01", periods=120, freq="T")
+        df = pd.DataFrame(
+            {
+                "Open": range(120),
+                "High": range(120),
+                "Low": range(120),
+                "Close": range(120),
+                "Volume": [1] * 120,
+            },
+            index=rng,
+        )
+        res = align_interval(df, "1h")
+        self.assertEqual(len(res), 2)
+
+    def test_align_interval_upsample(self):
+        rng = pd.date_range("2024-01-01", periods=2, freq="H")
+        df = pd.DataFrame({"Close": [1, 2]}, index=rng)
+        res = align_interval(df, "30m")
+        self.assertEqual(len(res), 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- enforce interval/lookback limits with `QueryParser.validate_interval_lookback`
- call validation from `QuantitativeAgent.preprocess_message`
- add `align_interval` helper to resample data
- expand unit tests for validation and resampling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499e92a1ac8323a3a14ff0b7a86774