### PR TITLE
Add ASCII sparkline output

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,5 @@ scikit-learn==1.6.1
 scipy 
 sec-edgar-downloader==5.0.3
 tiktoken
-yfinance 
+yfinance
+sparklines

--- a/src/agents/quantitative_agent.py
+++ b/src/agents/quantitative_agent.py
@@ -28,6 +28,7 @@ from src.tools.processors.indicator_library import (
     cci,
 )
 from src.tools.processors.data_normalizer import standardize_indicator_columns
+from sparklines import sparklines as _sparklines
 from src.tools.date_utils import (
     process_date_param,
     get_processed_date_range,
@@ -472,10 +473,14 @@ class QuantitativeAgent(BaseAgent):
                     and (df["Close"].iloc[-1] > df["ST"].iloc[-1])
                 )
 
+                n = min(len(df), 20)
+                spark = _sparklines(df["Close"].tail(n).tolist())[0]
+
                 return {
                     "latest_row": df.tail(1).to_dict(orient="records")[0],
                     "columns": list(df.columns),
                     "go_flag": "Go" if go_flag else "NoGo",
+                    "spark": spark,
                 }
 
         # ---------------------------------------------------------------

--- a/tests/test_quant_agent.py
+++ b/tests/test_quant_agent.py
@@ -24,3 +24,18 @@ def test_process_tool_result_macd():
         "fetch_market_data", df, {"indicators": ["macd"]}
     )
     assert "MACD_line" in result["latest_row"]
+
+
+def test_process_tool_result_spark():
+    agent = QuantitativeAgent()
+    df = pd.DataFrame(
+        {
+            "Open": range(1, 9),
+            "High": range(1, 9),
+            "Low": range(1, 9),
+            "Close": range(1, 9),
+            "Volume": [100] * 8,
+        }
+    )
+    result = agent.process_tool_result("fetch_market_data", df, {})
+    assert result["spark"] == "▁▂▃▄▅▆▇█"


### PR DESCRIPTION
## Summary
- add `sparklines` to requirements
- compute small ASCII sparkline in `QuantitativeAgent.process_tool_result`
- test sparkline generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0993c3348323aaf001a991f93a14