### PR TITLE
Add time zone localization utilities

### DIFF
--- a/quant_direct.py
+++ b/quant_direct.py
@@ -5,7 +5,10 @@ Direct mode only - Quantitative Agent online.
 import asyncio
 import os
 import traceback
+from datetime import datetime
+import pandas as pd
 from src.agents.quantitative_agent import QuantitativeAgent
+from src.tools.date_utils import get_default_timezone
 
 
 async def process_with_agent(prompt: str, agent: QuantitativeAgent):
@@ -35,6 +38,9 @@ def main():
         raise RuntimeError("OPEN_AI_KEY environment variable not set")
 
     print("Starting Quantitative Agent CLI...")
+    tz = get_default_timezone()
+    ts = pd.Timestamp.utcnow().tz_localize("UTC").tz_convert(tz)
+    print(f"Current time ({tz}): {ts.isoformat()}")
     agent = QuantitativeAgent()
 
     while True:

--- a/src/tools/data_sources/alpha_vantage_tool.py
+++ b/src/tools/data_sources/alpha_vantage_tool.py
@@ -13,7 +13,11 @@ from datetime import datetime
 from typing import Dict, Any, Optional
 import logging
 import os
-from src.tools.date_utils import get_processed_date_range
+from src.tools.date_utils import (
+    get_processed_date_range,
+    localize_df,
+    get_default_timezone,
+)
 
 
 class AlphaVantageTool:
@@ -138,6 +142,8 @@ class AlphaVantageTool:
 
             # Sort by date (newest first)
             df = df.sort_index(ascending=False)
+
+            df = localize_df(df, get_default_timezone())
 
             return df
 

--- a/src/tools/data_sources/market/alpha_vantage_market.py
+++ b/src/tools/data_sources/market/alpha_vantage_market.py
@@ -12,7 +12,11 @@ import logging
 import requests
 import pandas as pd
 import os
-from src.tools.date_utils import get_processed_date_range
+from src.tools.date_utils import (
+    get_processed_date_range,
+    localize_df,
+    get_default_timezone,
+)
 
 
 class AlphaVantageMarketTool:
@@ -119,6 +123,8 @@ class AlphaVantageMarketTool:
 
             # Sort by date (newest first)
             df = df.sort_index(ascending=False)
+
+            df = localize_df(df, get_default_timezone())
 
             return df
 

--- a/src/tools/data_sources/market/fmp_tool.py
+++ b/src/tools/data_sources/market/fmp_tool.py
@@ -10,7 +10,7 @@ import logging
 import pandas as pd
 from typing import Optional
 import os
-from src.tools.date_utils import process_date_param
+from src.tools.date_utils import process_date_param, localize_df, get_default_timezone
 
 
 class FMPTool:
@@ -525,6 +525,8 @@ class FMPTool:
                 # Keep only OHLCV columns
                 ohlcv_columns = ['Open', 'High', 'Low', 'Close', 'Volume']
                 df = df[[col for col in ohlcv_columns if col in df.columns]]
+
+                df = localize_df(df, get_default_timezone())
 
             return df
 

--- a/src/tools/data_sources/market/market_data_tool.py
+++ b/src/tools/data_sources/market/market_data_tool.py
@@ -9,7 +9,11 @@ import pandas as pd
 import os
 from src.tools.data_sources.alpha_vantage_tool import AlphaVantageTool
 from src.tools.data_sources.market.yahoo_finance_tool import YahooFinanceTool
-from src.tools.date_utils import get_processed_date_range
+from src.tools.date_utils import (
+    get_processed_date_range,
+    localize_df,
+    get_default_timezone,
+)
 
 
 class MarketDataTool:
@@ -97,14 +101,18 @@ class MarketDataTool:
 
         # Route to the appropriate data source
         if self.data_source == "alpha_vantage":
-            return self._fetch_from_alpha_vantage(symbol, start_date, end_date, filters)
+            df = self._fetch_from_alpha_vantage(symbol, start_date, end_date, filters)
         elif self.data_source == "yahoo":
-            return self._fetch_from_yahoo(symbol, start_date, end_date, filters)
+            df = self._fetch_from_yahoo(symbol, start_date, end_date, filters)
         elif self.data_source == "csv":
-            return self._fetch_from_csv(symbol, start_date, end_date, filters)
+            df = self._fetch_from_csv(symbol, start_date, end_date, filters)
         else:
             self.logger.error(f"Unsupported data_source: {self.data_source}")
             return pd.DataFrame()
+
+        if not df.empty:
+            df = localize_df(df, get_default_timezone())
+        return df
 
     def _fetch_from_alpha_vantage(
         self,
@@ -201,6 +209,8 @@ class MarketDataTool:
                 df = df[df.index >= start_date]
             if end_date:
                 df = df[df.index <= end_date]
+
+            df = localize_df(df, get_default_timezone())
 
             return df
 

--- a/src/tools/data_sources/market/yahoo_finance_tool.py
+++ b/src/tools/data_sources/market/yahoo_finance_tool.py
@@ -4,7 +4,7 @@ import logging
 import time
 from typing import Optional
 from datetime import datetime, timedelta
-from src.tools.date_utils import get_processed_date_range
+from src.tools.date_utils import get_processed_date_range, localize_df, get_default_timezone
 
 # Global cache and throttling variables
 _last_request_time = {}
@@ -197,6 +197,7 @@ class YahooFinanceTool:
                 result = pd.DataFrame()
             else:
                 result = df[['Open', 'High', 'Low', 'Close', 'Volume']]
+                result = localize_df(result, get_default_timezone())
 
             # Cache the result
             _store_in_cache(cache_key, result)

--- a/src/tools/date_utils.py
+++ b/src/tools/date_utils.py
@@ -3,7 +3,37 @@ Utilities for dynamic date handling in data tools.
 """
 
 import datetime
+import os
 from typing import Tuple, Optional
+
+
+DEFAULT_TIMEZONE = "America/New_York"
+
+
+def get_default_timezone() -> str:
+    """Return the configured default timezone."""
+    return os.getenv("DEFAULT_TIMEZONE", DEFAULT_TIMEZONE)
+
+
+def localize_df(df, tz: str):
+    """Ensure a DataFrame index is timezone-aware using the provided timezone."""
+    import pandas as pd
+
+    if df.empty:
+        return df
+
+    if not isinstance(df.index, pd.DatetimeIndex):
+        for col in ["timestamp", "date", "datetime", "Date", "Timestamp"]:
+            if col in df.columns:
+                df = df.set_index(pd.to_datetime(df[col]))
+                break
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise ValueError("DataFrame must have a datetime index or column")
+
+    if df.index.tz is None:
+        df.index = df.index.tz_localize("UTC")
+    df.index = df.index.tz_convert(tz)
+    return df
 
 
 def get_default_date_range(days_back: int = 5) -> Tuple[str, str]:

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -137,6 +137,21 @@ class TestDateUtils(unittest.TestCase):
         res = align_interval(df, "30m")
         self.assertEqual(len(res), 3)
 
+    def test_localize_df_naive_and_aware(self):
+        tz = "America/New_York"
+        rng_naive = pd.date_range("2024-01-01", periods=3, freq="D")
+        df_naive = pd.DataFrame({"Close": [1, 2, 3]}, index=rng_naive)
+
+        from src.tools.date_utils import localize_df
+        localized = localize_df(df_naive.copy(), tz)
+        self.assertIsNotNone(localized.index.tz)
+        self.assertEqual(localized.index.tz.zone, tz)
+
+        rng_aware = pd.date_range("2024-01-01", periods=3, freq="D", tz="UTC")
+        df_aware = pd.DataFrame({"Close": [1, 2, 3]}, index=rng_aware)
+        localized2 = localize_df(df_aware.copy(), tz)
+        self.assertEqual(localized2.index.tz.zone, tz)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- standardize timezone configuration in `date_utils`
- drop support for loading from `config/config.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a08e399c48323a902c02eeb157e86