### PR TITLE
Enable AVWAP anchors

### DIFF
--- a/docs/indicator_library.md
+++ b/docs/indicator_library.md
@@ -19,3 +19,7 @@ All indicator output columns follow the pattern `INDICATOR_component`.
 | CCI | `CCI` |
 
 These names are returned in the QuantitativeAgent's `latest_row` dictionary so downstream tools can rely on a consistent schema.
+
+The `avwap` function accepts an optional `anchor_ts` parameter which can be an
+ISO date or event token (e.g. `earnings`). When provided, the AVWAP calculation
+starts from that timestamp.

--- a/src/agents/quantitative_agent.py
+++ b/src/agents/quantitative_agent.py
@@ -33,6 +33,7 @@ from src.tools.date_utils import (
     process_date_param,
     get_processed_date_range,
     get_default_date_range,
+    resolve_anchor,
 )
 from src.tools.agent_utils import QueryParser
 
@@ -68,6 +69,7 @@ class QuantitativeAgent(BaseAgent):
 
         # Optional: attach a logger
         self.logger = logging.getLogger(self.__class__.__name__)
+        self.last_query: Dict[str, Any] = {}
 
     @staticmethod
     def _get_max_indicator_window(indicators: List[str]) -> int:
@@ -124,6 +126,14 @@ class QuantitativeAgent(BaseAgent):
         lower_text = message.lower()
 
         parsed: Dict[str, Any] = {}
+        anchor = None
+
+        anchor_match = re.search(
+            r"(?:from|since)\s+(\d{4}-\d{2}-\d{2}|earnings|fomc|year[_ ]?open)",
+            lower_text,
+        )
+        if anchor_match:
+            anchor = anchor_match.group(1).replace(" ", "_")
 
         # 1. Extract ticker symbols (2-5 uppercase letters)
         ticker_patterns = [
@@ -426,6 +436,8 @@ class QuantitativeAgent(BaseAgent):
                     comparison_tickers.append(comp_ticker)
         parsed["comparison_tickers"] = comparison_tickers
 
+        parsed["anchor"] = anchor
+
         return parsed
 
     def format_supplementary_context(self, query: Dict[str, Any]) -> str:
@@ -511,11 +523,19 @@ class QuantitativeAgent(BaseAgent):
                 if "cci" in req:
                     df["CCI"] = cci(df["High"], df["Low"], df["Close"])
 
+                anchor_ts = None
+                anchor_warning = None
+
                 # ------- optional AVWAP (needs volume + explicit ask) --------
                 if "Volume" in df.columns and "avwap" in tool_args.get(
                     "indicators", []
                 ):
-                    df["AVWAP"] = avwap(df["Close"], df["Volume"])
+                    anchor_token = self.last_query.get("anchor") if hasattr(self, "last_query") else None
+                    anchor_ts = None
+                    anchor_warning = None
+                    if anchor_token:
+                        anchor_ts, anchor_warning = resolve_anchor(df, anchor_token)
+                    df["AVWAP"] = avwap(df["Close"], df["Volume"], anchor_ts=anchor_ts)
 
                 df = standardize_indicator_columns(df)
 
@@ -574,6 +594,8 @@ class QuantitativeAgent(BaseAgent):
                     "events": events,
                     "spark": spark,
                     "timestamp": timestamp,
+                    "anchor_ts": anchor_ts.isoformat() if anchor_ts is not None else None,
+                    "anchor_warning": anchor_warning,
                 }
 
         # ---------------------------------------------------------------
@@ -589,6 +611,7 @@ class QuantitativeAgent(BaseAgent):
         # --------------- Extract last user message -------------------------
         last_msg = messages[-1]["content"] if messages else ""
         query = self.preprocess_message(last_msg)
+        self.last_query = query
 
         # --------------- Compose system prompt ----------------------------
         # Example system prompt instructing the LLM about returned fields

--- a/src/tools/agent_utils.py
+++ b/src/tools/agent_utils.py
@@ -88,6 +88,7 @@ class QueryParser:
         start_date = None
         end_date = None
         sector = None
+        anchor = None
 
         # List of common financial terms and abbreviations that aren't tickers
         common_terms = ["I", "A", "AI", "US", "ER", "GDP",
@@ -190,8 +191,13 @@ class QueryParser:
         if "since" in message_lower:
             after_since = message_lower.split("since")[-1].strip()
             words = after_since.split()
-            if words and (words[0].startswith("-") or words[0] in ["yesterday", "today", "ytd"]):
-                start_date = words[0]
+            if words:
+                if re.match(r"\d{4}-\d{2}-\d{2}", words[0]):
+                    anchor = words[0]
+                elif words[0] in ["earnings", "fomc", "year_open"]:
+                    anchor = words[0]
+                elif words[0].startswith("-") or words[0] in ["yesterday", "today", "ytd"]:
+                    start_date = words[0]
 
         if "last" in message_lower:
             after_last = message_lower.split("last")[-1].strip()
@@ -215,6 +221,17 @@ class QueryParser:
                         start_date = f"-{months}m"
                     except ValueError:
                         start_date = "-1m"
+
+        if not anchor:
+            match = re.search(
+                r"(?:from|since)\s+(earnings|fomc|year[_ ]?open)", message_lower
+            )
+            if match:
+                anchor = match.group(1).replace(" ", "_")
+        if not anchor:
+            match = re.search(r"(?:from|since)\s+(\d{4}-\d{2}-\d{2})", message_lower)
+            if match:
+                anchor = match.group(1)
 
         # For open-ended queries, extract topic using NLP techniques if needed
         if not topic and not ticker and len(message.split()) > 3:
@@ -264,7 +281,8 @@ class QueryParser:
             "topic": topic,
             "sector": sector,
             "start_date": start_date,
-            "end_date": end_date
+            "end_date": end_date,
+            "anchor": anchor,
         }
 
     @staticmethod

--- a/src/tools/date_utils.py
+++ b/src/tools/date_utils.py
@@ -4,6 +4,7 @@ Utilities for dynamic date handling in data tools.
 
 import datetime
 import os
+import re
 from typing import Tuple, Optional
 
 
@@ -239,3 +240,66 @@ def align_interval(df, interval):
     result = result.ffill().dropna(how="all")
     result.index.name = df.index.name
     return result
+
+
+def resolve_anchor(df, anchor_token):
+    """Resolve an anchor token to a timestamp within ``df``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame with a ``DatetimeIndex`` and optional event columns like
+        ``Earnings_Date`` or ``FOMC_Date``.
+    anchor_token : str | None
+        ISO date string (``YYYY-MM-DD``) or one of ``earnings``, ``fomc`` or
+        ``year_open``.
+
+    Returns
+    -------
+    tuple[pd.Timestamp, Optional[str]]
+        The resolved timestamp and an optional warning message when the token
+        could not be matched.  If ``anchor_token`` is ``None`` the first index
+        value is returned.
+    """
+    import pandas as pd
+    warning = None
+
+    if df.empty or not isinstance(df.index, pd.DatetimeIndex):
+        raise ValueError("DataFrame must be non-empty with a DatetimeIndex")
+
+    anchor_ts = df.index[0]
+
+    if not anchor_token:
+        return pd.Timestamp(anchor_ts), warning
+
+    try:
+        # ISO date pattern
+        if re.match(r"\d{4}-\d{2}-\d{2}", str(anchor_token)):
+            ts = pd.Timestamp(anchor_token)
+            idx = df.index.get_indexer([ts], method="nearest")[0]
+            anchor_ts = df.index[idx]
+        else:
+            token = str(anchor_token).lower()
+            if token == "year_open":
+                year_start = pd.Timestamp(df.index[-1].year, 1, 1,
+                                          tz=df.index.tz)
+                idx = df.index.get_indexer([year_start], method="bfill")[0]
+                anchor_ts = df.index[idx]
+            elif token in {"earnings", "fomc"}:
+                col_match = None
+                for c in df.columns:
+                    if token in c.lower():
+                        col_match = c
+                        break
+                if col_match:
+                    series = pd.to_datetime(df[col_match]).dropna()
+                    if not series.empty:
+                        anchor_ts = series.iloc[-1]
+                    else:
+                        warning = f"No {token} date found"
+                else:
+                    warning = f"No {token} date found"
+    except Exception as e:  # pragma: no cover - unexpected edge cases
+        warning = str(e)
+
+    return pd.Timestamp(anchor_ts), warning

--- a/src/tools/processors/indicator_library.py
+++ b/src/tools/processors/indicator_library.py
@@ -86,17 +86,29 @@ def supertrend(
 
 # --- AVWAP ---
 def avwap(
-    close: pd.Series, volume: pd.Series, anchor_idx: int | str | pd.Timestamp = 0
+    close: pd.Series,
+    volume: pd.Series,
+    anchor_ts: int | str | pd.Timestamp = 0,
 ) -> pd.Series:
+    """Anchored VWAP.
+
+    Parameters
+    ----------
+    close : pd.Series
+        Close prices.
+    volume : pd.Series
+        Volume series.
+    anchor_ts : int | str | pd.Timestamp, optional
+        Anchor position (index value, ISO date string, or integer index).
+        Defaults to the first row when ``0``.
     """
-    Anchored VWAP.  `anchor_idx` can be
-      • int  - positional index (0 = first row in frame),
-      • str  - e.g. "2025-05-20 09:30",
-      • pd.Timestamp.
-    """
-    if isinstance(anchor_idx, (str, pd.Timestamp)):
-        anchor_idx = close.index.get_loc(
-            pd.Timestamp(anchor_idx), method="nearest")
+    anchor_idx = 0
+    if anchor_ts is not None:
+        if isinstance(anchor_ts, (str, pd.Timestamp)):
+            anchor_idx = close.index.get_indexer(
+                [pd.Timestamp(anchor_ts)], method="nearest")[0]
+        elif isinstance(anchor_ts, int):
+            anchor_idx = anchor_ts
     pv = (close * volume).cumsum()
     vol = volume.cumsum()
     if anchor_idx > 0:

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -12,6 +12,7 @@ from src.tools.date_utils import (
     process_date_param,
     get_processed_date_range,
     align_interval,
+    resolve_anchor,
 )
 from src.tools.agent_utils import QueryParser
 import pandas as pd
@@ -151,6 +152,27 @@ class TestDateUtils(unittest.TestCase):
         df_aware = pd.DataFrame({"Close": [1, 2, 3]}, index=rng_aware)
         localized2 = localize_df(df_aware.copy(), tz)
         self.assertEqual(localized2.index.tz.zone, tz)
+
+    def test_resolve_anchor_iso(self):
+        rng = pd.date_range("2025-05-01", periods=3, freq="D")
+        df = pd.DataFrame({"Close": [1, 2, 3]}, index=rng)
+        ts, warn = resolve_anchor(df, "2025-05-02")
+        self.assertEqual(ts, pd.Timestamp("2025-05-02"))
+        self.assertIsNone(warn)
+
+    def test_resolve_anchor_missing_event(self):
+        rng = pd.date_range("2025-05-01", periods=2, freq="D")
+        df = pd.DataFrame({"Close": [1, 2]}, index=rng)
+        ts, warn = resolve_anchor(df, "earnings")
+        self.assertEqual(ts, df.index[0])
+        self.assertIsNotNone(warn)
+
+    def test_resolve_anchor_year_open(self):
+        rng = pd.date_range("2025-05-01", periods=3, freq="D")
+        df = pd.DataFrame({"Close": [1, 2, 3]}, index=rng)
+        ts, warn = resolve_anchor(df, "year_open")
+        self.assertEqual(ts, df.index[0])
+        self.assertIsNone(warn)
 
 
 if __name__ == '__main__':

--- a/tests/test_indicator_library.py
+++ b/tests/test_indicator_library.py
@@ -43,8 +43,16 @@ class TestIndicatorLibrary(unittest.TestCase):
     def test_avwap(self):
         close = pd.Series([1, 2, 3])
         volume = pd.Series([1, 1, 1])
-        result = avwap(close, volume, anchor_idx=0)
+        result = avwap(close, volume, anchor_ts=0)
         expected = pd.Series([1.0, 1.5, 2.0])
+        pd.testing.assert_series_equal(result, expected)
+
+    def test_avwap_anchor_ts_date(self):
+        idx = pd.date_range("2025-05-01", periods=3, freq="D")
+        close = pd.Series([1, 2, 3], index=idx)
+        volume = pd.Series([1, 1, 1], index=idx)
+        result = avwap(close, volume, anchor_ts="2025-05-02")
+        expected = pd.Series([float('nan'), 2.0, 2.5], index=idx)
         pd.testing.assert_series_equal(result, expected)
 
     def test_atr(self):

--- a/tests/test_quant_agent.py
+++ b/tests/test_quant_agent.py
@@ -63,6 +63,26 @@ def test_process_tool_result_rich_dict():
     assert isinstance(result["timestamp"], str)
 
 
+def test_avwap_anchor_in_result():
+    agent = QuantitativeAgent()
+    agent.last_query = {"anchor": "2025-01-02"}
+    idx = pd.date_range("2025-01-01", periods=3, freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": [1, 2, 3],
+            "High": [1, 2, 3],
+            "Low": [1, 1, 2],
+            "Close": [1, 2, 3],
+            "Volume": [100, 100, 100],
+        },
+        index=idx,
+    )
+    result = agent.process_tool_result(
+        "fetch_market_data", df, {"indicators": ["avwap"]}
+    )
+    assert result["anchor_ts"].startswith("2025-01-02")
+
+
 def test_preprocess_extends_for_indicators():
     agent = QuantitativeAgent()
     parsed = agent.preprocess_message("AAPL last 5 days with rsi(14)")

--- a/tests/test_query_parser.py
+++ b/tests/test_query_parser.py
@@ -1,0 +1,12 @@
+import pytest
+from src.tools.agent_utils import QueryParser
+
+def test_extract_anchor_date():
+    qp = QueryParser(market_sectors={})
+    details = qp.extract_query_details("Show AVWAP since 2025-05-01 for AAPL")
+    assert details["anchor"] == "2025-05-01"
+
+def test_extract_anchor_keyword():
+    qp = QueryParser(market_sectors={})
+    details = qp.extract_query_details("AVWAP from earnings on AAPL")
+    assert details["anchor"] == "earnings"


### PR DESCRIPTION
## Summary
- parse anchor keywords and ISO dates in QueryParser
- support anchor_ts resolution in `date_utils.resolve_anchor`
- allow setting anchor_ts in AVWAP indicator
- surface anchor info in QuantitativeAgent results
- document `anchor_ts` usage
- add comprehensive unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4346913483239ca4dd59c53e2644