### PR TITLE
Rename QuantitativeAgent to TechAgent

### DIFF
--- a/docs/UML/System/RH2MAS_UML_Diagram.mmd
+++ b/docs/UML/System/RH2MAS_UML_Diagram.mmd
@@ -53,7 +53,7 @@ classDiagram
         +reportConfidenceMetrics()
     }
     
-    class QuantitativeAnalysisAgent {
+    class TechAnalysisAgent {
         -technicalIndicators: Indicator[]
         -volatilityModels: Model[]
         +analyzeMarketStructure(data: TimeSeries)
@@ -152,12 +152,12 @@ classDiagram
     
     StrategyAgent --> DecisionEngine : "coordinates decisions"
     StrategyAgent --> SentimentAnalysisAgent : "delegates sentiment analysis"
-    StrategyAgent --> QuantitativeAnalysisAgent : "delegates quant analysis"
+    StrategyAgent --> TechAnalysisAgent : "delegates technical analysis"
     StrategyAgent --> MarketAnalysisAgent : "delegates market analysis"
     
     %% All agent signals routed via MetaTokenSystem
     SentimentAnalysisAgent --> MetaTokenSystem : "sends sentiment signals"
-    QuantitativeAnalysisAgent --> MetaTokenSystem : "sends technical signals"
+    TechAnalysisAgent --> MetaTokenSystem : "sends technical signals"
     MarketAnalysisAgent --> MetaTokenSystem : "sends market signals"
     
     MetaTokenSystem --> DecisionEngine : "synthesizes agent signals"
@@ -185,7 +185,7 @@ classDiagram
     
     %% Memory interactions
     SentimentAnalysisAgent --> LayeredMemorySystem : "stores/retrieves patterns"
-    QuantitativeAnalysisAgent --> LayeredMemorySystem : "stores/retrieves patterns"
+    TechAnalysisAgent --> LayeredMemorySystem : "stores/retrieves patterns"
     MarketAnalysisAgent --> LayeredMemorySystem : "stores/retrieves patterns"
     DecisionEngine --> LayeredMemorySystem : "Stores risk constraints and decision logs"
     PerformanceMonitor --> LayeredMemorySystem : "logs performance data"
@@ -198,7 +198,7 @@ classDiagram
     
     %% Custom Tools usage
     SentimentAnalysisAgent --> CustomTools : "utilizes sentiment API"
-    QuantitativeAnalysisAgent --> CustomTools : "utilizes technical analysis API"
+    TechAnalysisAgent --> CustomTools : "utilizes technical analysis API"
     MarketAnalysisAgent --> CustomTools : "utilizes market data API"
     DecisionEngine --> CustomTools : "fetches external financial data"
     R_MCTS_Module --> CustomTools : "retrieves training data for self-learning"

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -15,7 +15,7 @@
 ## Agent System
 
 - Sentiment analysis
-- Quantitative processing
+- Technical analysis
 - Market analysis
 - Strategy coordination
 

--- a/docs/architecture/data source tools.md
+++ b/docs/architecture/data source tools.md
@@ -228,7 +228,7 @@ Since the SentimentAgent and StrategyAgent are the simplest to implement first, 
 |-------------------|--------------------------------------------------------------------------------------------------|
 | **SentimentAgent** | UnifiedNewsTool, AlphaVantageNewsTool, FinnHubTool, NewsHeadlineTool, SECEdgarTool              |
 | **StrategyAgent**  | MarketDataTool, AlphaVantageMarketTool, YahooFinanceTool, UnifiedNewsTool, FREDDataTool         |
-| **QuantitativeAgent** | MarketDataTool, AlphaVantageMarketTool, YahooFinanceTool, FREDDataTool                         |
+| **TechAgent** | MarketDataTool, AlphaVantageMarketTool, YahooFinanceTool, FREDDataTool                         |
 | **RiskAgent**      | SECEdgarTool, FREDDataTool, MarketDataTool                                                       |
 
 ### Unified Tool Access

--- a/docs/indicator_library.md
+++ b/docs/indicator_library.md
@@ -1,6 +1,6 @@
 # Technical Indicator Library
 
-The `indicator_library` module provides common TA indicators used by the QuantitativeAgent.
+The `indicator_library` module provides common TA indicators used by the TechAgent.
 All indicator output columns follow the pattern `INDICATOR_component`.
 
 | Indicator | Columns Produced |
@@ -18,7 +18,7 @@ All indicator output columns follow the pattern `INDICATOR_component`.
 | Stochastic RSI | `StochRSI`, `StochRSI_K`, `StochRSI_D` |
 | CCI | `CCI` |
 
-These names are returned in the QuantitativeAgent's `latest_row` dictionary so downstream tools can rely on a consistent schema.
+These names are returned in the TechAgent's `latest_row` dictionary so downstream tools can rely on a consistent schema.
 
 The `avwap` function accepts an optional `anchor_ts` parameter which can be an
 ISO date or event token (e.g. `earnings`). When provided, the AVWAP calculation

--- a/docs/research/Frameworks/NotesOnAutoGen.md
+++ b/docs/research/Frameworks/NotesOnAutoGen.md
@@ -18,7 +18,7 @@ Inter-Agent Communication
 Leverage AutoGen’s orchestration to streamline RH2MAS agent hierarchy:
 
   - **Sentiment Agent**: Use AutoGen’s LLM fine-tuning capabilities to process textual market sentiment.
-  - **Quantitative Agent**: Implement technical analysis modules (e.g., moving averages, Bollinger Bands) using custom templates.
+  - **Tech Agent**: Implement technical analysis modules (e.g., moving averages, Bollinger Bands) using custom templates.
   - **Market Agent**: Aggregate macroeconomic signals and apply AutoGen’s API chaining for real-time updates.
   - **Strategy Agent**: Integrate AutoGen’s debate and reflection capabilities for decision synthesis based on agent input​Reflective_Hybrid_Head_….
 - **Step 2**: Adapt Communication and Coordination

--- a/docs/research/Frameworks/understandingAutoGen.md
+++ b/docs/research/Frameworks/understandingAutoGen.md
@@ -18,7 +18,7 @@ Inter-Agent Communication
 Leverage AutoGen’s orchestration to streamline RH2MAS agent hierarchy:
 
   - **Sentiment Agent**: Use AutoGen’s LLM fine-tuning capabilities to process textual market sentiment.
-  - **Quantitative Agent**: Implement technical analysis modules (e.g., moving averages, Bollinger Bands) using custom templates.
+  - **Tech Agent**: Implement technical analysis modules (e.g., moving averages, Bollinger Bands) using custom templates.
   - **Market Agent**: Aggregate macroeconomic signals and apply AutoGen’s API chaining for real-time updates.
   - **Strategy Agent**: Integrate AutoGen’s debate and reflection capabilities for decision synthesis based on agent input​Reflective_Hybrid_Head_….
 - **Step 2**: Adapt Communication and Coordination

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,3 +1,4 @@
 from .base_agent import BaseAgent
 from .sentiment_agent import SentimentAgent
 from .strategy_agent import StrategyAgent
+from .tech_agent import TechAgent

--- a/src/agents/tech_agent.py
+++ b/src/agents/tech_agent.py
@@ -12,7 +12,7 @@ import numpy as np
 
 # project imports
 from src.agents.base_agent import BaseAgent
-from src.tools.tools import QUANTITATIVE_AGENT, get_tools_for_agent
+from src.tools.tools import TECH_AGENT, get_tools_for_agent
 from src.tools.processors.indicator_library import (
     sma,
     ema,
@@ -37,7 +37,7 @@ from src.tools.date_utils import (
 )
 from src.tools.agent_utils import QueryParser
 
-QUANT_LLM_CONFIG = {
+TECH_LLM_CONFIG = {
     "temperature": 0.15,  # deterministic outputs
     "max_tokens": 4096,
     "top_p": 0.9,
@@ -45,9 +45,9 @@ QUANT_LLM_CONFIG = {
 }
 
 
-class QuantitativeAgent(BaseAgent):
+class TechAgent(BaseAgent):
     """
-    Agent that answers quantitative / technical-analysis questions.
+    Agent that answers technical-analysis questions.
 
     Responsibilities
     ----------------
@@ -56,15 +56,15 @@ class QuantitativeAgent(BaseAgent):
     • Generate concise, data-driven explanations for the user.
     """
 
-    def __init__(self, name: str = "QuantitativeAgent", memory_system=None):
-        # Select only the quantitative-tagged tools
-        tools = get_tools_for_agent(QUANTITATIVE_AGENT)
+    def __init__(self, name: str = "TechAgent", memory_system=None):
+        # Select only the tech-agent-tagged tools
+        tools = get_tools_for_agent(TECH_AGENT)
 
         super().__init__(
             name=name,
             tools=tools,
             memory_system=memory_system,
-            llm_config=QUANT_LLM_CONFIG,
+            llm_config=TECH_LLM_CONFIG,
         )
 
         # Optional: attach a logger
@@ -455,7 +455,7 @@ class QuantitativeAgent(BaseAgent):
                             ", ".join(query["indicators"]))
 
         snippets.append(
-            "Available quantitative tools: fetch_market_data, fetch_yahoo_data, "
+            "Available technical tools: fetch_market_data, fetch_yahoo_data, "
             "fetch_economic_indicator, fetch_interest_rates, fetch_yield_curve"
         )
 
@@ -616,7 +616,7 @@ class QuantitativeAgent(BaseAgent):
         # --------------- Compose system prompt ----------------------------
         # Example system prompt instructing the LLM about returned fields
         sys_prompt = (
-            "You are a quantitative research assistant. "
+            "You are a technical research assistant. "
             "When useful, call tools to fetch data, then compute indicators "
             "locally before you answer.\n"
             "\nSupplementary context:\n"

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -23,10 +23,10 @@ import os
 
 # Agent Types
 SENTIMENT_AGENT = "sentiment"
-QUANTITATIVE_AGENT = "quantitative"
+TECH_AGENT = "tech"
 RISK_AGENT = "risk"
 STRATEGY_AGENT = "strategy"
-ALL_AGENTS = [SENTIMENT_AGENT, QUANTITATIVE_AGENT, RISK_AGENT, STRATEGY_AGENT]
+ALL_AGENTS = [SENTIMENT_AGENT, TECH_AGENT, RISK_AGENT, STRATEGY_AGENT]
 
 # CORPORATE ACTIONS TOOL HIERARCHY:
 # 1. PRIMARY: Yahoo Finance tools - Free but rate limited, enhanced with caching/throttling
@@ -553,7 +553,7 @@ yahoo_finance_tool = FunctionTool(
     description="Fetch stock price data from Yahoo Finance for a given ticker and date range."
 )
 # Only quant and strategy agents handle price data
-yahoo_finance_tool.agent_types = [QUANTITATIVE_AGENT, STRATEGY_AGENT]
+yahoo_finance_tool.agent_types = [TECH_AGENT, STRATEGY_AGENT]
 
 
 def fetch_yahoo_corporate_events(
@@ -615,7 +615,7 @@ alpha_vantage_tool = FunctionTool(
     description="Fetch stock price data from Alpha Vantage for a given ticker and date range."
 )
 # Only quant and strategy agents handle price data
-alpha_vantage_tool.agent_types = [QUANTITATIVE_AGENT, STRATEGY_AGENT]
+alpha_vantage_tool.agent_types = [TECH_AGENT, STRATEGY_AGENT]
 
 
 def fetch_market_data(
@@ -647,7 +647,7 @@ market_data_tool = FunctionTool(
     description="Fetch market data from specified source for a given ticker and date range."
 )
 # Only quant and strategy agents handle price data
-market_data_tool.agent_types = [QUANTITATIVE_AGENT, STRATEGY_AGENT]
+market_data_tool.agent_types = [TECH_AGENT, STRATEGY_AGENT]
 
 ##################################
 # 6) FRED Economic Data Tool
@@ -687,7 +687,7 @@ fred_indicator_tool = FunctionTool(
     description="Fetch economic indicator data from FRED (Federal Reserve)."
 )
 # Relevant for quant and strategy agents
-fred_indicator_tool.agent_types = [QUANTITATIVE_AGENT, STRATEGY_AGENT]
+fred_indicator_tool.agent_types = [TECH_AGENT, STRATEGY_AGENT]
 
 
 def fetch_interest_rates(
@@ -717,7 +717,7 @@ fred_rates_tool = FunctionTool(
     description="Fetch interest rate data from FRED (Federal Reserve)."
 )
 # Relevant for multiple agents
-fred_rates_tool.agent_types = [QUANTITATIVE_AGENT, STRATEGY_AGENT, RISK_AGENT]
+fred_rates_tool.agent_types = [TECH_AGENT, STRATEGY_AGENT, RISK_AGENT]
 
 
 def fetch_yield_curve(date: str = "today") -> pd.DataFrame:
@@ -741,7 +741,7 @@ fred_yield_curve_tool = FunctionTool(
     description="Fetch the Treasury yield curve for a specific date."
 )
 fred_yield_curve_tool.agent_types = [
-    QUANTITATIVE_AGENT, STRATEGY_AGENT, RISK_AGENT]  # Relevant for multiple agents
+    TECH_AGENT, STRATEGY_AGENT, RISK_AGENT]  # Relevant for multiple agents
 
 ##################################
 # 7) SEC EDGAR Filings Tool (EXPERIMENTAL)
@@ -884,8 +884,8 @@ SENTIMENT_TOOLS = [
     finnhub_earnings_estimates_tool,  # Finnhub earnings estimates (PREMIUM)
 ]
 
-# QUANTITATIVE_AGENT tools
-QUANTITATIVE_TOOLS = [
+# TECH_AGENT tools
+TECH_TOOLS = [
     yahoo_finance_tool,
     alpha_vantage_tool,
     market_data_tool,
@@ -933,7 +933,7 @@ STRATEGY_TOOLS = [
 # All tools combined
 ALL_TOOLS = list(set(
     SENTIMENT_TOOLS +
-    QUANTITATIVE_TOOLS +
+    TECH_TOOLS +
     RISK_TOOLS +
     STRATEGY_TOOLS
 ))
@@ -953,15 +953,15 @@ def get_tools_for_agent(agent_type):
     Get the list of tools that should be used by a specific agent type.
 
     Args:
-        agent_type: Type of agent (e.g., 'sentiment', 'quantitative')
+        agent_type: Type of agent (e.g., 'sentiment', 'tech')
 
     Returns:
         List of FunctionTool objects appropriate for the agent type
     """
     if agent_type == SENTIMENT_AGENT:
         return SENTIMENT_TOOLS
-    elif agent_type == QUANTITATIVE_AGENT:
-        return QUANTITATIVE_TOOLS
+    elif agent_type == TECH_AGENT:
+        return TECH_TOOLS
     elif agent_type == RISK_AGENT:
         return RISK_TOOLS
     elif agent_type == STRATEGY_AGENT:

--- a/tech_direct.py
+++ b/tech_direct.py
@@ -1,5 +1,5 @@
 """
-Direct mode only - Quantitative Agent online.
+Direct mode only - Tech Agent online.
 """
 
 import asyncio
@@ -7,13 +7,13 @@ import os
 import traceback
 from datetime import datetime
 import pandas as pd
-from src.agents.quantitative_agent import QuantitativeAgent
+from src.agents.tech_agent import TechAgent
 from src.tools.date_utils import get_default_timezone
 
 
-async def process_with_agent(prompt: str, agent: QuantitativeAgent):
+async def process_with_agent(prompt: str, agent: TechAgent):
     """
-    Send a single prompt to the QuantitativeAgent and return the response.
+    Send a single prompt to the TechAgent and return the response.
     Handles both synchronous and coroutine returns (process_with_tools_async).
     """
     try:
@@ -37,11 +37,11 @@ def main():
     if not os.environ.get("OPEN_AI_KEY"):
         raise RuntimeError("OPEN_AI_KEY environment variable not set")
 
-    print("Starting Quantitative Agent CLI...")
+    print("Starting Tech Agent CLI...")
     tz = get_default_timezone()
-    ts = pd.Timestamp.utcnow().tz_localize("UTC").tz_convert(tz)
+    ts = pd.Timestamp.utcnow().tz_convert(tz)
     print(f"Current time ({tz}): {ts.isoformat()}")
-    agent = QuantitativeAgent()
+    agent = TechAgent()
 
     while True:
         try:

--- a/tests/test_tech_agent.py
+++ b/tests/test_tech_agent.py
@@ -1,16 +1,16 @@
 import pandas as pd
-from src.agents.quantitative_agent import QuantitativeAgent
+from src.agents.tech_agent import TechAgent
 
 
 def test_preprocess_macd():
-    agent = QuantitativeAgent()
+    agent = TechAgent()
     parsed = agent.preprocess_message("Show me MACD for TSLA")
     names = [i.split("(")[0] for i in parsed["indicators"]]
     assert "macd" in names
 
 
 def test_process_tool_result_macd():
-    agent = QuantitativeAgent()
+    agent = TechAgent()
     df = pd.DataFrame(
         {
             "Open": [1, 2, 3, 4, 5, 6],
@@ -27,7 +27,7 @@ def test_process_tool_result_macd():
 
 
 def test_process_tool_result_spark():
-    agent = QuantitativeAgent()
+    agent = TechAgent()
     df = pd.DataFrame(
         {
             "Open": range(1, 9),
@@ -42,7 +42,7 @@ def test_process_tool_result_spark():
 
 
 def test_process_tool_result_rich_dict():
-    agent = QuantitativeAgent()
+    agent = TechAgent()
     df = pd.DataFrame(
         {
             "Open": [1, 2, 3, 4],
@@ -64,7 +64,7 @@ def test_process_tool_result_rich_dict():
 
 
 def test_avwap_anchor_in_result():
-    agent = QuantitativeAgent()
+    agent = TechAgent()
     agent.last_query = {"anchor": "2025-01-02"}
     idx = pd.date_range("2025-01-01", periods=3, freq="D")
     df = pd.DataFrame(
@@ -84,7 +84,7 @@ def test_avwap_anchor_in_result():
 
 
 def test_preprocess_extends_for_indicators():
-    agent = QuantitativeAgent()
+    agent = TechAgent()
     parsed = agent.preprocess_message("AAPL last 5 days with rsi(14)")
     start = pd.to_datetime(parsed["start_date"])
     end = pd.to_datetime(parsed["end_date"])


### PR DESCRIPTION
## Summary
- rename `quantitative_agent` module and class to `tech_agent`
- adjust constants and tool registration for tech agent
- update CLI script to `tech_direct.py`
- migrate unit tests to use `TechAgent`
- refresh docs and UML to reference Tech Agent

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `printf 'AAPL with sma(5)\nexit\n' | python tech_direct.py`

------
https://chatgpt.com/codex/tasks/task_e_684c576484708323beba8405e65a431d