### PR TITLE
Update capability docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,39 @@
 # Core Components
 
-## Hybrid-Head
+This folder contains the main documentation for the research prototype. The
+project is built around a **multi‑agent system** with shared memory and a set of
+data–retrieval tools. Below is a quick overview of what is implemented today.
 
-Neural architecture combining attention and state space models.
+## Hybrid‑Head
 
-## Memory System  
+Neural architecture combining attention and state space models. The current code
+uses this design indirectly through pre‑trained models to keep memory usage low.
 
-Layered memory implementation with RadixAttention cache.
+## Memory System
+
+Layered memory implementation with a RadixAttention cache. Agents can store and
+retrieve conversation context or intermediate results from this system.
 
 ## Agent Framework
 
-Base agent classes and communication protocols.
+The framework defines four specialized agents.  At this stage the Sentiment and
+Tech agents are operational, while the Risk and Strategy agents are still
+experimental.
+
+1. **Sentiment Agent** – fetches financial news and analyses sentiment using LLM
+   function calling.  Supports date‑range and ticker queries through a unified
+   tool.
+2. **Tech Agent** – performs technical analysis with indicators such as EMA,
+   MACD and ATR on market data retrieved from common APIs.
+3. **Risk Agent** – prototype utilities for scanning SEC filings.
+4. **Strategy Agent** – early orchestrator that combines other agents’ output.
+
+Agents communicate via a lightweight orchestrator and a message bus. Each agent
+only sees the tools it needs, reducing prompt noise and API usage.
 
 ## Reference Documentation
 
-- [AutoGen Core Reference](autogen_core_reference/README.md) - Reference documentation for AutoGen Core 0.5.x components used in RH2MAS
+- [AutoGen Core Reference](autogen_core_reference/README.md) – Reference
+  documentation for AutoGen Core 0.6.x components used in RH2MAS
+- [Status Summary: Sentiment and Tech Agents](status_summary_sentiment_tech_agents.md) – High-level overview of the active agents and their limitations
+

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -2,10 +2,15 @@
 
 ## Components
 
-- Hybrid Neural Core
-- Memory System
-- Agent Framework
-- Risk Analysis Engine
+- **Hybrid Neural Core** – combines attention and state‑space models for
+  efficient sequence processing.
+- **Memory System** – layered storage with RadixAttention caching.
+- **Agent Framework** – base classes for the Sentiment and Tech agents (active),
+  with experimental Risk and Strategy agents under development.
+- **Risk Analysis Engine** – utilities for parsing SEC filings and calculating
+  exposure (prototype stage).
+- **Agent Orchestrator** – routes messages among agents via a shared message bus
+  and ensures each agent only sees the tools it requires.
 
 ## Design Principles
 
@@ -13,3 +18,4 @@
 2. Layered memory management
 3. Explainable decision-making
 4. Dynamic risk adaptation
+5. Clear separation of concerns between agents

--- a/docs/status_summary_sentiment_tech_agents.md
+++ b/docs/status_summary_sentiment_tech_agents.md
@@ -1,0 +1,38 @@
+# Status Summary: Sentiment and Tech Agents
+
+This document provides a brief overview of the two active agents in RH2MAS and their current development status. It is intended for project stakeholders evaluating the next experimental stage. Details are subject to change as the system evolves.
+
+## 1. Executive Summary
+
+- **Purpose** – Outline the present capabilities of the Sentiment and Tech agents.
+- **Status** – Both agents are functional and routinely tested, while Risk and Strategy agents remain in prototype form.
+- **Current Milestone** – Preparing for an initial evaluation of these agents' analytic output in a closed environment.
+
+## 2. Current Version and Scope of Functionality
+
+### Sentiment Agent
+
+- Retrieves news articles by ticker and date range using an aggregated news service.
+- Returns a short sentiment label for each article (positive, neutral, negative).
+
+**Known limitations**
+
+- Coverage depends on the external APIs included in the aggregator.
+- Long date ranges may produce incomplete results.
+
+### Tech Agent
+
+- Fetches historical price data and computes standard indicators such as EMA, MACD, RSI and ATR.
+- Designed for analytical insights only; does not place trades or manage portfolios.
+
+**Known limitations**
+
+- Intraday data is not always available for every ticker.
+- Multi-ticker comparisons are not yet supported.
+
+### Technical Notes
+
+- Both agents run as part of a multi-agent orchestrator executed from the command line.
+- Interaction is via text prompts; results are returned in JSON or table form.
+
+These notes capture the current state of development. Capabilities and interfaces may change as the project progresses.


### PR DESCRIPTION
## Summary
- replace system capabilities doc with new status summary for Sentiment and Tech agents
- update docs README to reference the new summary and autogen 0.6.x
- revert README change about active agents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68501bec1e5883238187bf3bb8ab821f