### PR TITLE
Add coordinator agent

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -2,3 +2,4 @@ from .base_agent import BaseAgent
 from .sentiment_agent import SentimentAgent
 from .strategy_agent import StrategyAgent
 from .tech_agent import TechAgent
+from .coordinator_agent import CoordinatorAgent

--- a/src/agents/coordinator_agent.py
+++ b/src/agents/coordinator_agent.py
@@ -1,0 +1,38 @@
+"""Coordinator Agent module.
+
+This agent coordinates the SentimentAgent and TechnicalAgent
+and exposes an API to fetch combined signals.
+"""
+
+from typing import Any, Dict
+import asyncio
+
+from .base_agent import BaseAgent
+from .sentiment_agent import SentimentAgent
+from .tech_agent import TechAgent
+
+
+class CoordinatorAgent(BaseAgent):
+    """Agent that orchestrates SentimentAgent and TechnicalAgent."""
+
+    def __init__(self, name: str = "CoordinatorAgent", memory_system: Any = None):
+        super().__init__(name=name, tools=[], memory_system=memory_system)
+        self.sentiment = SentimentAgent()
+        self.technical = TechAgent()
+
+    async def get_signals(self, date: str, symbol: str) -> Dict[str, Any]:
+        """Return sentiment and technical signals for a symbol on a date."""
+        prompt = f"analyse {symbol} on {date}"
+        try:
+            sentiment_resp = self.sentiment.generate_reply([{"role": "user", "content": prompt}])
+            if asyncio.iscoroutine(sentiment_resp):
+                sentiment_resp = await sentiment_resp
+
+            tech_resp = self.technical.generate_reply([{"role": "user", "content": prompt}])
+            if asyncio.iscoroutine(tech_resp):
+                tech_resp = await tech_resp
+
+            return {"ok": True, "sentiment": sentiment_resp, "technical": tech_resp}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+


### PR DESCRIPTION
## Summary
- implement `CoordinatorAgent` for orchestrating sentiment & technical analysis
- expose new agent via package initializer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599ae56f3c83238f4182c80823b560