### PR TITLE
Add improved MAS runner

### DIFF
--- a/scripts/run_mas.py
+++ b/scripts/run_mas.py
@@ -1,0 +1,65 @@
+"""Run a minimal multi-agent simulation over a date range.
+
+This CLI loops over a calendar range, obtains signals from a
+``CoordinatorAgent`` and passes them to a ``StrategyAgent``.  The
+decisions are printed as JSON on stdout.
+"""
+
+import argparse
+import json
+from datetime import datetime, timedelta, date
+
+from src.agents.coordinator_agent import CoordinatorAgent
+from src.agents.strategy_agent import StrategyAgent
+from src.tools.date_utils import get_processed_date_range
+
+
+def iter_days(start: date, end: date):
+    """Yield each day between ``start`` and ``end`` inclusive."""
+
+    d = start
+    while d <= end:
+        yield d
+        d += timedelta(days=1)
+
+
+def main() -> None:
+    """Entry point for the demo CLI."""
+
+    parser = argparse.ArgumentParser(
+        description="Run MAS demo over a date range",
+    )
+    parser.add_argument(
+        "--start",
+        type=str,
+        help="Start date (YYYY-MM-DD or relative)",
+    )
+    parser.add_argument(
+        "--end",
+        type=str,
+        help="End date (YYYY-MM-DD or relative)",
+    )
+    parser.add_argument(
+        "--symbol",
+        default="AAPL",
+        help="Ticker symbol to analyze",
+    )
+    args = parser.parse_args()
+
+    # Parse the date range using date_utils to support relative strings
+    start_str, end_str = get_processed_date_range(args.start, args.end)
+    start_dt = datetime.strptime(start_str, "%Y-%m-%d").date()
+    end_dt = datetime.strptime(end_str, "%Y-%m-%d").date()
+
+    coord = CoordinatorAgent()
+    strat = StrategyAgent()
+
+    for day in iter_days(start_dt, end_dt):
+        signals = coord.get_signals(day.isoformat(), args.symbol)
+        decision = strat.decide_trade(signals)
+        print(json.dumps({"date": day.isoformat(), "decision": decision}))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,4 +1,5 @@
 from .base_agent import BaseAgent
 from .sentiment_agent import SentimentAgent
 from .strategy_agent import StrategyAgent
+from .coordinator_agent import CoordinatorAgent
 from .tech_agent import TechAgent

--- a/src/agents/coordinator_agent.py
+++ b/src/agents/coordinator_agent.py
@@ -1,0 +1,14 @@
+"""Placeholder coordinator agent."""
+
+from .base_agent import BaseAgent
+
+
+class CoordinatorAgent(BaseAgent):
+    """Minimal coordinator agent that returns dummy signals."""
+
+    def __init__(self, name: str = "CoordinatorAgent", memory_system=None):
+        super().__init__(name=name, memory_system=memory_system)
+
+    def get_signals(self, date_str: str, ticker: str):
+        """Return stub signals for a given date and ticker."""
+        return {"date": date_str, "ticker": ticker, "signal": "neutral"}

--- a/src/agents/strategy_agent.py
+++ b/src/agents/strategy_agent.py
@@ -1,4 +1,14 @@
+"""Simple placeholder strategy agent."""
+
 from .base_agent import BaseAgent
 
 
 class StrategyAgent(BaseAgent):
+    """Placeholder StrategyAgent implementation."""
+
+    def __init__(self, name: str = "StrategyAgent", memory_system=None):
+        super().__init__(name=name, memory_system=memory_system)
+
+    def decide_trade(self, signals):
+        """Return a dummy trade decision based on signals."""
+        return {"decision": "hold", "signals": signals}


### PR DESCRIPTION
## Summary
- refine run_mas CLI
- accept start/end dates via date_utils
- loop over days and print StrategyAgent decisions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68599bad3810832396d6c5303918d9f7