### PR TITLE
Add MACD sentiment strategy

### DIFF
--- a/src/agents/strategy_agent.py
+++ b/src/agents/strategy_agent.py
@@ -1,31 +1,65 @@
+from datetime import datetime
+from typing import Dict
+
 from .base_agent import BaseAgent
 
 
 class StrategyAgent(BaseAgent):
-    """Simple rule-based trading agent.
+    """Implements a basic MACD + sentiment trading strategy."""
 
-    The agent receives aggregated signals from a coordinator and decides on a
-    trading action. If the sentiment signal is positive and the technical
-    analysis indicates a "go" signal, it returns a BUY order. Otherwise it
-    returns a HOLD order.
-    """
+    def __init__(self, name: str = "StrategyAgent", memory_system=None):
+        super().__init__(name=name, tools=[], memory_system=memory_system)
+        self.position = 0  # 0 = flat, 1 = long
+        self.entry_price = None
+        self.trade_log = []
 
-    def decide_trade(self, aggregated: Dict) -> Dict:
-        """Return a trading decision based on aggregated signals.
+    def generate_reply(self, messages, context=None):
+        """Stub implementation required by BaseAgent."""
+        raise NotImplementedError("StrategyAgent does not support conversations")
 
-        Parameters
-        ----------
-        aggregated : Dict
-            Dictionary containing at least ``"sentiment"`` and ``"technical"``
-            keys with sub-dictionaries.
+    def decide_trade(self, aggregated: Dict, price: float, trade_date: str) -> Dict:
+        """Return a BUY/SELL/HOLD decision based on MACD crossovers and sentiment."""
+        macd_y = aggregated["technical"].get("macd_yest")
+        macd_t = aggregated["technical"].get("macd_today")
+        sentiment = aggregated["sentiment"].get("score", 0)
 
-        Returns
-        -------
-        Dict
-            Order dictionary with action ("BUY" or "HOLD"), fixed quantity, and
-            a reason string.
-        """
-        sent = aggregated.get("sentiment", {})
-        tech = aggregated.get("technical", {})
-        action = "BUY" if sent.get("score", 0) > 0 and tech.get("go") else "HOLD"
-        return {"action": action, "qty": 100, "reason": "rule_v0"}
+        action = "HOLD"
+
+        # ----- ENTRY -----
+        if self.position == 0:
+            if (
+                macd_y is not None
+                and macd_y < 0
+                and macd_t is not None
+                and macd_t > macd_y
+                and sentiment > 0
+            ):
+                action = "BUY"
+                self.position = 1
+                self.entry_price = price
+
+        # ----- EXIT -----
+        elif self.position == 1:
+            if (
+                (macd_y is not None and macd_y < 0 and macd_t < macd_y)
+                or (macd_y is not None and macd_y > 0 and macd_t < 0)
+            ):
+                action = "SELL"
+                self.position = 0
+
+        self.trade_log.append(
+            {
+                "date": trade_date,
+                "action": action,
+                "price": price,
+                "macd_t": macd_t,
+                "macd_y": macd_y,
+                "sent": sentiment,
+            }
+        )
+
+        return {
+            "action": action,
+            "qty": 100 if action == "BUY" else 0,
+            "reason": "macd_sent_rule_v1",
+        }

--- a/tests/test_mas_flow.py
+++ b/tests/test_mas_flow.py
@@ -1,14 +1,13 @@
 import pytest
 
-from src.agents.coordinator_agent import CoordinatorAgent
 from src.agents.strategy_agent import StrategyAgent
-from src.tools.date_utils import process_date_param
 
 
 def test_simple_flow():
-    date = process_date_param("2024-01-05")
-    coord = CoordinatorAgent()
     strat = StrategyAgent()
-    agg = coord.get_signals(date, "AAPL")
-    dec = strat.decide_trade(agg)
-    assert dec["action"] in ("BUY", "HOLD")
+    aggregated = {
+        "technical": {"macd_yest": -1.0, "macd_today": -0.5},
+        "sentiment": {"score": 0.2},
+    }
+    decision = strat.decide_trade(aggregated, price=100.0, trade_date="2025-01-01")
+    assert decision["action"] in {"BUY", "SELL", "HOLD"}


### PR DESCRIPTION
## Summary
- implement stateful MACD-based trading logic
- stub out `generate_reply` to satisfy BaseAgent
- simplify `test_mas_flow` to use mock data

## Testing
- `PYTHONPATH=./ pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a2ff018c832396e52d1a802e805e