### PR TITLE
Add smoke test and fix agent init

### DIFF
--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -523,12 +523,15 @@ class BaseAgent(AssistantAgent, ABC):
         """
         try:
             messages = self._build_message_sequence(prompt, system_prompt)
-            # If already in an event loop, use the async version directly
-            if asyncio.get_event_loop().is_running():
-                # Return a coroutine that can be awaited by the caller
+            try:
+                asyncio.get_running_loop()
+                in_loop = True
+            except RuntimeError:
+                in_loop = False
+
+            if in_loop:
                 return self.process_with_tools_async(prompt, system_prompt)
             else:
-                # Not in an event loop, safe to use asyncio.run
                 response = asyncio.run(self._run_tool_conversation(messages))
                 return self._extract_content(response)
         except Exception as e:

--- a/src/agents/coordinator_agent.py
+++ b/src/agents/coordinator_agent.py
@@ -20,17 +20,21 @@ class CoordinatorAgent(BaseAgent):
         self.sentiment = SentimentAgent()
         self.technical = TechAgent()
 
-    async def get_signals(self, date: str, symbol: str) -> Dict[str, Any]:
+    def generate_reply(self, messages, context=None):
+        """Placeholder to satisfy the BaseAgent interface."""
+        raise NotImplementedError("CoordinatorAgent does not implement dialogue responses")
+
+    def get_signals(self, date: str, symbol: str) -> Dict[str, Any]:
         """Return sentiment and technical signals for a symbol on a date."""
         prompt = f"analyse {symbol} on {date}"
         try:
             sentiment_resp = self.sentiment.generate_reply([{"role": "user", "content": prompt}])
             if asyncio.iscoroutine(sentiment_resp):
-                sentiment_resp = await sentiment_resp
+                sentiment_resp = asyncio.run(sentiment_resp)
 
             tech_resp = self.technical.generate_reply([{"role": "user", "content": prompt}])
             if asyncio.iscoroutine(tech_resp):
-                tech_resp = await tech_resp
+                tech_resp = asyncio.run(tech_resp)
 
             return {"ok": True, "sentiment": sentiment_resp, "technical": tech_resp}
         except Exception as e:

--- a/src/agents/strategy_agent.py
+++ b/src/agents/strategy_agent.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from .base_agent import BaseAgent
 
 
@@ -9,6 +11,9 @@ class StrategyAgent(BaseAgent):
     analysis indicates a "go" signal, it returns a BUY order. Otherwise it
     returns a HOLD order.
     """
+
+    def __init__(self, name: str = "StrategyAgent", memory_system=None):
+        super().__init__(name=name, tools=[], memory_system=memory_system)
 
     def decide_trade(self, aggregated: Dict) -> Dict:
         """Return a trading decision based on aggregated signals.
@@ -26,6 +31,14 @@ class StrategyAgent(BaseAgent):
             a reason string.
         """
         sent = aggregated.get("sentiment", {})
+        if isinstance(sent, str):
+            sent = {}
         tech = aggregated.get("technical", {})
+        if isinstance(tech, str):
+            tech = {}
         action = "BUY" if sent.get("score", 0) > 0 and tech.get("go") else "HOLD"
         return {"action": action, "qty": 100, "reason": "rule_v0"}
+
+    def generate_reply(self, messages, context=None):
+        """Placeholder to satisfy the BaseAgent interface."""
+        raise NotImplementedError("StrategyAgent does not implement dialogue responses")

--- a/tests/test_hardcoded_strategy.py
+++ b/tests/test_hardcoded_strategy.py
@@ -1,0 +1,16 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_pipeline_runs():
+    from src.agents.coordinator_agent import CoordinatorAgent
+    from src.agents.strategy_agent import StrategyAgent
+
+    coord = CoordinatorAgent(); strat = StrategyAgent()
+    for _ in range(5):
+        sigs = coord.get_signals("2025-05-01", "AAPL")
+        assert sigs["ok"]
+        dec = strat.decide_trade(sigs)
+        assert dec["action"] in {"BUY", "SELL", "HOLD"}


### PR DESCRIPTION
## Summary
- ensure CoordinatorAgent provides get_signals synchronously
- make StrategyAgent instantiable and robust to string signals
- avoid event loop errors in BaseAgent
- add a smoke-test for strategy over multiple sessions

## Testing
- `pytest -q`
- `pytest tests/test_hardcoded_strategy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6859a35708988323b5ed2ee32e83924f