### PR TITLE
Improve Yahoo fallback handling

### DIFF
--- a/src/tools/data_sources/market/yahoo_finance_tool.py
+++ b/src/tools/data_sources/market/yahoo_finance_tool.py
@@ -78,7 +78,7 @@ def _retry_on_rate_limit(func, *args, max_retries=3, **kwargs):
         except Exception as e:
             if "Too Many Requests" in str(e) or "Rate limited" in str(e):
                 if attempt < max_retries - 1:
-                    wait_time = (2 ** attempt) * 5  # 5, 10, 20 seconds
+                    wait_time = (2 ** attempt) * 0.5  # 0.5, 1, 2 seconds
                     logging.warning(
                         f"Rate limited, waiting {wait_time} seconds before retry {attempt + 1}")
                     time.sleep(wait_time)


### PR DESCRIPTION
## Summary
- tweak yahoo finance API retry wait times to be shorter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abb02f6b88323b829baf2fb7a9924