### PR TITLE
Add config fallback for env vars

### DIFF
--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -38,10 +38,14 @@ from src.tools.tools import (
     fetch_fmp_stock_split_calendar
 )
 import os
+from src.config_loader import ConfigLoader
 
-# Read configuration from environment variables
-model_name = os.getenv("OPEN_MODEL")  # e.g. "gpt-4o-mini"
-open_ai_key = os.getenv("OPEN_AI_KEY")
+# Load configuration file for fallback values
+config_loader = ConfigLoader()
+
+# Read configuration from environment variables or fallback to config
+model_name = os.getenv("OPEN_MODEL", config_loader.get("OPEN_MODEL"))
+open_ai_key = os.getenv("OPEN_AI_KEY", config_loader.get("OPEN_AI_KEY"))
 
 # Fallback map for tool execution
 TOOL_FUNCTION_MAP = {

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -1,0 +1,27 @@
+import json
+import os
+
+
+class ConfigLoader:
+    def __init__(self, config_path=None):
+        # Determine the config file path relative to this file
+        if config_path is None:
+            # Assuming config folder is in the project root
+            base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            config_path = os.path.join(base_dir, "config", "config.json")
+        self.config_path = config_path
+        self.config = self.load_config()
+
+    def load_config(self):
+        try:
+            with open(self.config_path, "r") as file:
+                config = json.load(file)
+            return config
+        except Exception as e:
+            # If the config file is missing, fall back to an empty dict
+            # to avoid import errors across environments.
+            print(f"Warning: could not load config file: {e}")
+            return {}
+
+    def get(self, key, default=None):
+        return self.config.get(key, default)

--- a/src/tools/data_sources/alpha_vantage_tool.py
+++ b/src/tools/data_sources/alpha_vantage_tool.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from typing import Dict, Any, Optional
 import logging
 import os
+from src.config_loader import ConfigLoader
 from src.tools.date_utils import (
     get_processed_date_range,
     localize_df,
@@ -37,8 +38,11 @@ class AlphaVantageTool:
             stacklevel=2
         )
 
-        # Load API key from environment
-        self.api_key = os.getenv("ALPHA_VANTAGE_KEY")
+        # Load API key from environment or config
+        config_loader = ConfigLoader()
+        self.api_key = os.getenv(
+            "ALPHA_VANTAGE_KEY", config_loader.get("ALPHA_VANTAGE_KEY")
+        )
 
         if not self.api_key:
             logging.warning("Alpha Vantage API key not found in config.")

--- a/src/tools/data_sources/government/FRED_data_tool.py
+++ b/src/tools/data_sources/government/FRED_data_tool.py
@@ -13,6 +13,9 @@ import logging
 from typing import Optional, Dict, Any, List
 from fredapi import Fred
 import os
+from src.config_loader import ConfigLoader
+
+config_loader = ConfigLoader()
 from src.tools.date_utils import process_date_param, get_processed_date_range
 
 
@@ -65,7 +68,7 @@ class FREDDataTool:
 
         # Load API key from environment if not provided
         if api_key is None:
-            api_key = os.getenv("FREDAPI")
+            api_key = os.getenv("FREDAPI", config_loader.get("FREDAPI"))
 
             if not api_key:
                 self.logger.error("No FRED API key provided in environment")

--- a/src/tools/data_sources/government/sec_edgar_tool.py
+++ b/src/tools/data_sources/government/sec_edgar_tool.py
@@ -7,6 +7,9 @@ and analyzing the content. It works primarily with 10-K, 10-Q, 8-K and other fil
 """
 
 import os
+from src.config_loader import ConfigLoader
+
+config_loader = ConfigLoader()
 import re
 import logging
 import tempfile
@@ -42,7 +45,7 @@ REPORT_SECTIONS = {
     "executive_compensation": ["executive compensation", "item 11", "item11"]
 }
 
-email = os.getenv("validEmail")
+email = os.getenv("validEmail", config_loader.get("validEmail"))
 
 
 class SECEdgarTool:

--- a/src/tools/data_sources/market/alpha_vantage_market.py
+++ b/src/tools/data_sources/market/alpha_vantage_market.py
@@ -12,6 +12,7 @@ import logging
 import requests
 import pandas as pd
 import os
+from src.config_loader import ConfigLoader
 from src.tools.date_utils import (
     get_processed_date_range,
     localize_df,
@@ -29,8 +30,11 @@ class AlphaVantageMarketTool:
     """
 
     def __init__(self):
-        # Load API key from environment
-        self.api_key = os.getenv("ALPHA_VANTAGE_KEY")
+        # Load API key from environment or config
+        config_loader = ConfigLoader()
+        self.api_key = os.getenv(
+            "ALPHA_VANTAGE_KEY", config_loader.get("ALPHA_VANTAGE_KEY")
+        )
 
         if not self.api_key:
             logging.warning("Alpha Vantage API key not found in config.")

--- a/src/tools/data_sources/market/fmp_tool.py
+++ b/src/tools/data_sources/market/fmp_tool.py
@@ -10,6 +10,7 @@ import logging
 import pandas as pd
 from typing import Optional
 import os
+from src.config_loader import ConfigLoader
 from src.tools.date_utils import process_date_param, localize_df, get_default_timezone
 
 
@@ -36,7 +37,8 @@ class FMPTool:
 
         # Load API key from environment if not provided
         if api_key is None:
-            api_key = os.getenv("FMP")
+            config_loader = ConfigLoader()
+            api_key = os.getenv("FMP", config_loader.get("FMP"))
 
             if not api_key:
                 self.logger.error("No FMP API key provided in environment")

--- a/src/tools/data_sources/market/market_data_tool.py
+++ b/src/tools/data_sources/market/market_data_tool.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any, Dict, Optional
 import pandas as pd
 import os
+from src.config_loader import ConfigLoader
 from src.tools.data_sources.alpha_vantage_tool import AlphaVantageTool
 from src.tools.data_sources.market.yahoo_finance_tool import YahooFinanceTool
 from src.tools.date_utils import (
@@ -40,13 +41,21 @@ class MarketDataTool:
 
         # Load from environment if config not provided
         if config is None:
-            default_days_back = int(os.getenv("DEFAULT_DAYS_BACK", 5))
+            config_loader = ConfigLoader()
+            default_days_back = int(
+                os.getenv("DEFAULT_DAYS_BACK", config_loader.get("DEFAULT_DAYS_BACK", 5))
+            )
             default_date_range = get_processed_date_range(
                 default_days_back=default_days_back)
 
             self.config = {
-                "data_source": os.getenv("MARKET_DATA_SOURCE", "alpha_vantage"),
-                "default_symbol": os.getenv("DEFAULT_SYMBOL", "AAPL"),
+                "data_source": os.getenv(
+                    "MARKET_DATA_SOURCE",
+                    config_loader.get("MARKET_DATA_SOURCE", "alpha_vantage"),
+                ),
+                "default_symbol": os.getenv(
+                    "DEFAULT_SYMBOL", config_loader.get("DEFAULT_SYMBOL", "AAPL")
+                ),
                 "default_date_range": default_date_range,
                 "default_days_back": default_days_back,
             }

--- a/src/tools/data_sources/news/alpha_vantage_news.py
+++ b/src/tools/data_sources/news/alpha_vantage_news.py
@@ -11,6 +11,7 @@ import logging
 import requests
 import pandas as pd
 import os
+from src.config_loader import ConfigLoader
 
 
 class AlphaVantageNewsTool:
@@ -23,8 +24,11 @@ class AlphaVantageNewsTool:
     """
 
     def __init__(self):
-        # Load API key from environment
-        self.api_key = os.getenv("ALPHA_VANTAGE_KEY")
+        # Load API key from environment or config
+        config_loader = ConfigLoader()
+        self.api_key = os.getenv(
+            "ALPHA_VANTAGE_KEY", config_loader.get("ALPHA_VANTAGE_KEY")
+        )
 
         if not self.api_key:
             logging.warning("Alpha Vantage API key not found in config.")

--- a/src/tools/data_sources/news/finnhub_tool.py
+++ b/src/tools/data_sources/news/finnhub_tool.py
@@ -9,6 +9,7 @@ retrieval for sentiment analysis.
 
 import requests
 import logging
+from src.config_loader import ConfigLoader
 import pandas as pd
 from typing import Optional, List
 import os
@@ -52,7 +53,8 @@ class FinnHubTool:
 
         # Load API key from environment if not provided
         if api_key is None:
-            api_key = os.getenv("FINNHUB_KEY")
+            config_loader = ConfigLoader()
+            api_key = os.getenv("FINNHUB_KEY", config_loader.get("FINNHUB_KEY"))
 
             if not api_key:
                 self.logger.error("No Finnhub API key provided in environment")

--- a/src/tools/data_sources/news/news_headline_tool.py
+++ b/src/tools/data_sources/news/news_headline_tool.py
@@ -2,6 +2,9 @@
 import sys
 from datetime import datetime
 import os
+from src.config_loader import ConfigLoader
+
+config_loader = ConfigLoader()
 import requests
 import pandas as pd
 import nltk
@@ -13,7 +16,7 @@ class NewsHeadlineTool:
 
     def __init__(self, source="newsapi"):
         # Load configuration and API key from environment
-        self.api_key = os.getenv("NEWSAPI_KEY")
+        self.api_key = os.getenv("NEWSAPI_KEY", config_loader.get("NEWSAPI_KEY"))
         self.source = source
 
         # Initialize sentiment analyzer

--- a/src/tools/data_sources/news/unified_news_tool.py
+++ b/src/tools/data_sources/news/unified_news_tool.py
@@ -16,6 +16,9 @@ Features:
 import os
 import json
 import asyncio
+from src.config_loader import ConfigLoader
+
+config_loader = ConfigLoader()
 from datetime import datetime
 from typing import List, Dict, Any, Optional, Union, Literal
 from abc import ABC, abstractmethod
@@ -90,7 +93,10 @@ class NewsSourceProvider(ABC):
     def _load_api_key(self):
         """Load API key from environment if configured"""
         if self.config.api_key_config_name:
-            self.api_key = os.getenv(self.config.api_key_config_name.upper())
+            self.api_key = os.getenv(
+                self.config.api_key_config_name.upper(),
+                config_loader.get(self.config.api_key_config_name.upper()),
+            )
         else:
             self.api_key = None
 

--- a/src/tools/date_utils.py
+++ b/src/tools/date_utils.py
@@ -4,6 +4,9 @@ Utilities for dynamic date handling in data tools.
 
 import datetime
 import os
+from src.config_loader import ConfigLoader
+
+config_loader = ConfigLoader()
 import re
 from typing import Tuple, Optional
 
@@ -13,7 +16,10 @@ DEFAULT_TIMEZONE = "America/New_York"
 
 def get_default_timezone() -> str:
     """Return the configured default timezone."""
-    return os.getenv("DEFAULT_TIMEZONE", DEFAULT_TIMEZONE)
+    return os.getenv(
+        "DEFAULT_TIMEZONE",
+        config_loader.get("DEFAULT_TIMEZONE", DEFAULT_TIMEZONE),
+    )
 
 
 def localize_df(df, tz: str):

--- a/src/tools/tools.py
+++ b/src/tools/tools.py
@@ -12,6 +12,9 @@ from src.tools.data_sources.market.fmp_tool import FMPTool
 import pandas as pd
 from src.tools.processors.data_normalizer import normalize_data_for_sentiment
 import os
+from src.config_loader import ConfigLoader
+
+config_loader = ConfigLoader()
 # Import other vendor tools as needed
 
 ##################################
@@ -316,7 +319,7 @@ def fetch_finnhub_news(
         DataFrame with financial news headlines, dates, and sources
     """
     # Load API key from environment
-    api_key = os.getenv("FINNHUB_KEY")
+    api_key = os.getenv("FINNHUB_KEY", config_loader.get("FINNHUB_KEY"))
 
     tool = FinnHubTool(api_key)
     df = tool.fetch_news(category=category, tickers=tickers, count=count)
@@ -347,7 +350,7 @@ def fetch_finnhub_financial_headlines(
         DataFrame with diverse financial headlines for sentiment analysis
     """
     # Load API key from environment
-    api_key = os.getenv("FINNHUB_KEY")
+    api_key = os.getenv("FINNHUB_KEY", config_loader.get("FINNHUB_KEY"))
 
     tool = FinnHubTool(api_key)
     df = tool.fetch_financial_headlines(count=count)
@@ -378,12 +381,12 @@ def fetch_finnhub_economic_headlines(
         DataFrame with economic headlines from Finnhub
     """
     # Load API key from environment
-    api_key = os.getenv("FINNHUB_KEY")
+    api_key = os.getenv("FINNHUB_KEY", config_loader.get("FINNHUB_KEY"))
 
     tool = FinnHubTool(api_key)
     df = tool.fetch_economic_headlines(count=count)
     # Load API key from environment
-    api_key = os.getenv("FINNHUB_KEY")
+    api_key = os.getenv("FINNHUB_KEY", config_loader.get("FINNHUB_KEY"))
 
     tool = FinnHubTool(api_key)
     df = tool.fetch_economic_headlines(count=count)
@@ -414,7 +417,7 @@ def fetch_finnhub_earnings_calendar(
         DataFrame with earnings calendar data including EPS estimates and actuals
     """
     # Load API key from environment
-    api_key = os.getenv("FINNHUB_KEY")
+    api_key = os.getenv("FINNHUB_KEY", config_loader.get("FINNHUB_KEY"))
 
     tool = FinnHubTool(api_key)
     df = tool.fetch_earnings_calendar(start_date, end_date)
@@ -446,7 +449,7 @@ def fetch_finnhub_insider_transactions(
         DataFrame with insider transaction data
     """
     # Load API key from environment
-    api_key = os.getenv("FINNHUB_KEY")
+    api_key = os.getenv("FINNHUB_KEY", config_loader.get("FINNHUB_KEY"))
 
     tool = FinnHubTool(api_key)
     df = tool.fetch_insider_transactions(symbol, start_date, end_date)
@@ -479,7 +482,7 @@ def fetch_finnhub_dividends(
         DataFrame with dividend data including ex-dividend dates and amounts
     """
     # Load API key from environment
-    api_key = os.getenv("FINNHUB_KEY")
+    api_key = os.getenv("FINNHUB_KEY", config_loader.get("FINNHUB_KEY"))
 
     tool = FinnHubTool(api_key)
     df = tool.fetch_dividends(symbol, start_date, end_date)
@@ -507,7 +510,7 @@ def fetch_finnhub_earnings_estimates(
         DataFrame with EPS estimates and historical earnings surprises
     """
     # Load API key from environment
-    api_key = os.getenv("FINNHUB_KEY")
+    api_key = os.getenv("FINNHUB_KEY", config_loader.get("FINNHUB_KEY"))
 
     tool = FinnHubTool(api_key)
     df = tool.fetch_earnings_estimates(symbol)


### PR DESCRIPTION
## Summary
- add ConfigLoader to read config/config.json
- load model and key from config when environment variables are missing
- update various tools to use ConfigLoader fallback
- avoid failing when config file does not exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af59554e0832383a0caaa380372eb