### PR TITLE
Enforce single tool usage in agents

### DIFF
--- a/src/agents/sentiment_agent.py
+++ b/src/agents/sentiment_agent.py
@@ -322,6 +322,10 @@ class SentimentAgent(BaseAgent):
         # Create a system prompt with supplementary context
         system_prompt = self.config.get("system_prompt", "")
         system_prompt += f"\n\nSupplementary context for this query:\n{supplementary_context}"
+        system_prompt += (
+            "\n\nAfter you have executed ONE tool call and received its result, "
+            "STOP CALLING TOOLS and give your final answer."
+        )
 
         # Add specific guidance based on extracted entities
         if query_details.get("ticker"):

--- a/src/agents/tech_agent.py
+++ b/src/agents/tech_agent.py
@@ -632,6 +632,10 @@ class TechAgent(BaseAgent):
             + "\n\nIMPORTANT: Use multiple tools if it improves the answer."
             + "\nTool outputs include: latest_row, go_flag, go_rationale, risk, events, spark, timestamp."
         )
+        sys_prompt += (
+            "\n\nAfter you have executed ONE tool call and received its result, "
+            "STOP CALLING TOOLS and give your final answer."
+        )
 
         # --------------- Forward to BaseAgent’s tool-aware pipeline -------
         return self.process_with_tools(last_msg, sys_prompt)


### PR DESCRIPTION
## Summary
- reinforce single tool use in SentimentAgent
- reinforce single tool use in TechAgent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_685b14c76b448323bc053db1f560d9cc