### PR TITLE
Enforce per-agent tool round limit

### DIFF
--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -410,8 +410,8 @@ class BaseAgent(AssistantAgent, ABC):
     # Core Conversation Methods
     #############################
 
-    async def _run_tool_conversation(self, messages: List[Any], max_rounds: int = 2) -> Any:
-        """Run a conversation with optional tool calling, capped by ``max_rounds``."""
+    async def _run_tool_conversation(self, messages: List[Any]) -> Any:
+        """Run a conversation with optional tool calling."""
         rounds = 0
         conversation = list(messages)
         tools_list = list(self._tools_dict.values())
@@ -422,9 +422,10 @@ class BaseAgent(AssistantAgent, ABC):
             response = await self.model_client.create(messages=conversation, tools=tools_list)
 
             if hasattr(response, 'content') and isinstance(response.content, list):
+                # decide max rounds per-agent (default = 2)
+                max_rounds = getattr(self, 'max_tool_rounds', 2)
                 if rounds >= max_rounds:
-                    self.log(
-                        "Max tool rounds reached; stopping further tool calls.")
+                    self.log(f"{self.name}: reached max_tool_rounds={max_rounds}, stopping tool loop.")
                     break
                 conversation.append(AssistantMessage(
                     content=response.content, source="assistant"))
@@ -438,7 +439,9 @@ class BaseAgent(AssistantAgent, ABC):
         summary = await self.model_client.create(
             messages=conversation + [
                 AssistantMessage(
-                    content="Please summarize these findings in a final answer.", source="assistant")
+                    content="Summarize these findings in a final answer; do not call any more tools.",
+                    source="assistant"
+                )
             ]
         )
         return summary

--- a/src/agents/sentiment_agent.py
+++ b/src/agents/sentiment_agent.py
@@ -42,6 +42,8 @@ class SentimentAgent(BaseAgent):
     def __init__(self, name="SentimentAgent", memory_system=None):
         # Load configurations and utilities
         self.config = load_agent_config("sentiment_agent")
+        # limit to one tool round
+        self.max_tool_rounds = 1
         self.market_sectors = load_market_sectors().get("sectors", {})
         self.query_parser = QueryParser(self.market_sectors)
 


### PR DESCRIPTION
## Summary
- cap tool rounds in BaseAgent's `_run_tool_conversation`
- allow SentimentAgent to use only one tool call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_685b1b1364788323a3b645d53612b4de