### PR TITLE
Add market data fallbacks via FMP and Nasdaq DL

### DIFF
--- a/docs/architecture/data source tools.md
+++ b/docs/architecture/data source tools.md
@@ -140,6 +140,8 @@ src/tools/
 - Consistent DataFrame output format
 - Fallback capabilities between providers
   - If Yahoo Finance is rate limited, the tool automatically retries using Alpha Vantage
+  - If both fail, it falls back to FMP and finally Nasdaq Data Link
+  - FMP's free tier only supports basic historical price endpoints
 
 ### News Data Sources
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ sec-edgar-downloader==5.0.3
 tiktoken
 yfinance
 sparklines
+nasdaq-data-link==1.0.3

--- a/src/tools/data_sources/market/__init__.py
+++ b/src/tools/data_sources/market/__init__.py
@@ -10,5 +10,13 @@ This package contains tools for retrieving market data from various sources:
 from .alpha_vantage_market import AlphaVantageMarketTool
 from .yahoo_finance_tool import YahooFinanceTool
 from .market_data_tool import MarketDataTool
+from .fmp_tool import FMPTool
+from .nasdaq_data_link_tool import NasdaqDataLinkTool
 
-__all__ = ["AlphaVantageMarketTool", "YahooFinanceTool", "MarketDataTool"]
+__all__ = [
+    "AlphaVantageMarketTool",
+    "YahooFinanceTool",
+    "MarketDataTool",
+    "FMPTool",
+    "NasdaqDataLinkTool",
+]

--- a/src/tools/data_sources/market/market_data_tool.py
+++ b/src/tools/data_sources/market/market_data_tool.py
@@ -10,6 +10,8 @@ import os
 from config.config_loader import ConfigLoader
 from src.tools.data_sources.alpha_vantage_tool import AlphaVantageTool
 from src.tools.data_sources.market.yahoo_finance_tool import YahooFinanceTool
+from src.tools.data_sources.market.fmp_tool import FMPTool
+from src.tools.data_sources.market.nasdaq_data_link_tool import NasdaqDataLinkTool
 from src.tools.date_utils import (
     get_processed_date_range,
     localize_df,
@@ -74,6 +76,8 @@ class MarketDataTool:
         # Initialize specific data source tools
         self.alpha_vantage_tool = None
         self.yahoo_finance_tool = None
+        self.fmp_tool = None
+        self.nasdaq_dl_tool = None
 
         self.logger.info(
             f"MarketDataTool initialized with data_source={self.data_source}")
@@ -149,22 +153,26 @@ class MarketDataTool:
         if self.alpha_vantage_tool is None:
             self.alpha_vantage_tool = AlphaVantageTool()
 
-        # Fetch data
-        df = self.alpha_vantage_tool.fetch_stock_data(
-            symbol, start_date, end_date)
+        try:
+            df = self.alpha_vantage_tool.fetch_stock_data(
+                symbol, start_date, end_date)
+            if df is None or df.empty:
+                self.logger.warning(
+                    "Alpha Vantage returned no data, attempting FMP fallback")
+                return self._fetch_from_fmp(symbol, start_date, end_date, filters)
+        except Exception as e:
+            self.logger.warning(
+                f"Alpha Vantage error for {symbol}: {e}. Using FMP fallback")
+            return self._fetch_from_fmp(symbol, start_date, end_date, filters)
 
-        # Normalize column names to match Yahoo Finance format so downstream
-        # consumers can reliably use capitalized OHLCV columns.
-        if not df.empty:
-            col_map = {
-                "open": "Open",
-                "high": "High",
-                "low": "Low",
-                "close": "Close",
-                "volume": "Volume",
-            }
-            df = df.rename(
-                columns={k: v for k, v in col_map.items() if k in df.columns})
+        col_map = {
+            "open": "Open",
+            "high": "High",
+            "low": "Low",
+            "close": "Close",
+            "volume": "Volume",
+        }
+        df = df.rename(columns={k: v for k, v in col_map.items() if k in df.columns})
 
         return df
 
@@ -205,6 +213,46 @@ class MarketDataTool:
             self.logger.warning(
                 f"Yahoo Finance error for {symbol}: {e}. Using Alpha Vantage fallback")
             return self._fetch_from_alpha_vantage(symbol, start_date, end_date, filters)
+
+    def _fetch_from_fmp(
+        self,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> pd.DataFrame:
+        """Fetch market data from Financial Modeling Prep."""
+        if self.fmp_tool is None:
+            self.fmp_tool = FMPTool()
+
+        try:
+            df = self.fmp_tool.fetch_stock_data(symbol, start_date, end_date)
+            if df is None or df.empty:
+                self.logger.warning(
+                    "FMP returned no data, attempting Nasdaq Data Link fallback")
+                return self._fetch_from_nasdaq_dl(symbol, start_date, end_date, filters)
+            return df
+        except Exception as e:
+            self.logger.warning(
+                f"FMP error for {symbol}: {e}. Using Nasdaq Data Link fallback")
+            return self._fetch_from_nasdaq_dl(symbol, start_date, end_date, filters)
+
+    def _fetch_from_nasdaq_dl(
+        self,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> pd.DataFrame:
+        """Fetch market data from Nasdaq Data Link."""
+        if self.nasdaq_dl_tool is None:
+            self.nasdaq_dl_tool = NasdaqDataLinkTool()
+
+        try:
+            return self.nasdaq_dl_tool.fetch_stock_data(symbol, start_date, end_date)
+        except Exception as e:
+            self.logger.error(f"Nasdaq Data Link error for {symbol}: {e}")
+            return pd.DataFrame()
 
     def _fetch_from_csv(
         self,

--- a/src/tools/data_sources/market/nasdaq_data_link_tool.py
+++ b/src/tools/data_sources/market/nasdaq_data_link_tool.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Optional
+import os
+import pandas as pd
+import nasdaqdatalink
+from src.tools.date_utils import get_processed_date_range, localize_df, get_default_timezone
+
+
+class NasdaqDataLinkTool:
+    """Tool for fetching stock data from Nasdaq Data Link (Quandl)."""
+
+    def __init__(self, api_key: Optional[str] = None, verbose: bool = False):
+        self.logger = logging.getLogger(self.__class__.__name__)
+        if verbose:
+            logging.basicConfig(level=logging.INFO)
+
+        if api_key is None:
+            api_key = os.getenv("NASDAQ_DATA_LINK_KEY")
+        if api_key:
+            nasdaqdatalink.ApiConfig.api_key = api_key
+        else:
+            self.logger.warning("Nasdaq Data Link API key not provided")
+
+        self.default_dataset = "EOD"
+
+    def fetch_stock_data(
+        self,
+        symbol: str,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        dataset: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """Fetch OHLCV data for a symbol."""
+        if dataset is None:
+            dataset = self.default_dataset
+        try:
+            start_date, end_date = get_processed_date_range(start_date, end_date)
+            code = f"{dataset}/{symbol.upper()}"
+            df = nasdaqdatalink.get(
+                code, start_date=start_date, end_date=end_date
+            )
+            if df is None or df.empty:
+                self.logger.warning(f"No Nasdaq Data Link data for {symbol}")
+                return pd.DataFrame()
+
+            column_map = {
+                "Adj. Open": "Open",
+                "Adj. High": "High",
+                "Adj. Low": "Low",
+                "Adj. Close": "Close",
+                "Adj. Volume": "Volume",
+            }
+            df = df.rename(columns={k: v for k, v in column_map.items() if k in df.columns})
+            ohlcv_cols = ["Open", "High", "Low", "Close", "Volume"]
+            df = df[[col for col in ohlcv_cols if col in df.columns]]
+            df = localize_df(df, get_default_timezone())
+            return df
+        except Exception as e:
+            self.logger.error(f"Error fetching Nasdaq Data Link data: {e}")
+            return pd.DataFrame()

--- a/tests/test_market_data_tool.py
+++ b/tests/test_market_data_tool.py
@@ -4,6 +4,8 @@ import pytest
 from src.tools.data_sources.market.market_data_tool import MarketDataTool
 from src.tools.data_sources.alpha_vantage_tool import AlphaVantageTool
 from src.tools.data_sources.market.yahoo_finance_tool import YahooFinanceTool
+from src.tools.data_sources.market.fmp_tool import FMPTool
+from src.tools.data_sources.market.nasdaq_data_link_tool import NasdaqDataLinkTool
 
 
 def test_yahoo_fallback_to_alpha(monkeypatch):
@@ -35,3 +37,57 @@ def test_yahoo_fallback_to_alpha(monkeypatch):
     assert not df.empty
     assert list(df.columns) == list(sample.columns)
     assert df.iloc[0]["Open"] == 1.0
+
+
+def test_alpha_fallback_to_fmp(monkeypatch):
+    """Alpha Vantage failure triggers FMP fallback."""
+
+    def mock_yahoo_fail(self, symbol, start, end):
+        raise Exception("Rate limit")
+
+    def mock_alpha_fail(self, symbol, start, end):
+        raise Exception("API down")
+
+    idx = pd.to_datetime(["2023-01-02"])
+    sample = pd.DataFrame({"Open": [2.0], "High": [2.0], "Low": [2.0], "Close": [2.0], "Volume": [200]}, index=idx)
+
+    def mock_fmp_success(self, symbol, start, end):
+        return sample
+
+    monkeypatch.setattr(YahooFinanceTool, "fetch_stock_data", mock_yahoo_fail)
+    monkeypatch.setattr(AlphaVantageTool, "fetch_stock_data", mock_alpha_fail)
+    monkeypatch.setattr(FMPTool, "fetch_stock_data", mock_fmp_success)
+
+    tool = MarketDataTool({"data_source": "yahoo"})
+    df = tool.fetch_market_data("AAPL", "2023-01-01", "2023-01-02")
+    assert not df.empty
+    assert df.iloc[0]["Open"] == 2.0
+
+
+def test_fmp_fallback_to_nasdaq(monkeypatch):
+    """FMP failure triggers Nasdaq Data Link fallback."""
+
+    def mock_yahoo_fail(self, symbol, start, end):
+        return pd.DataFrame()
+
+    def mock_alpha_fail(self, symbol, start, end):
+        return pd.DataFrame()
+
+    def mock_fmp_fail(self, symbol, start, end):
+        return pd.DataFrame()
+
+    idx = pd.to_datetime(["2023-01-03"])
+    sample = pd.DataFrame({"Open": [3.0], "High": [3.0], "Low": [3.0], "Close": [3.0], "Volume": [300]}, index=idx)
+
+    def mock_nasdaq_success(self, symbol, start, end):
+        return sample
+
+    monkeypatch.setattr(YahooFinanceTool, "fetch_stock_data", mock_yahoo_fail)
+    monkeypatch.setattr(AlphaVantageTool, "fetch_stock_data", mock_alpha_fail)
+    monkeypatch.setattr(FMPTool, "fetch_stock_data", mock_fmp_fail)
+    monkeypatch.setattr(NasdaqDataLinkTool, "fetch_stock_data", mock_nasdaq_success)
+
+    tool = MarketDataTool({"data_source": "yahoo"})
+    df = tool.fetch_market_data("AAPL", "2023-01-01", "2023-01-03")
+    assert not df.empty
+    assert df.iloc[0]["Open"] == 3.0


### PR DESCRIPTION
## Summary
- implement NasdaqDataLinkTool for additional price data source
- extend MarketDataTool with FMP and Nasdaq Data Link fallbacks
- update docs on the fallback chain and note on FMP free tier
- test fallback behaviour
- drop private config loader files

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b33835a0883238e4bb8b0daf201cb