### PR TITLE
refactor(#440): Extract scheduler CLI components

### DIFF
--- a/src/cli/scheduler/__init__.py
+++ b/src/cli/scheduler/__init__.py
@@ -1,0 +1,17 @@
+"""Scheduler CLI components - refactored from scheduler_cli.py (Issue #440)."""
+
+from .config_editor import SchedulerConfigEditor
+from .daemon_manager import SchedulerDaemonManager
+from .message_loader import SchedulerMessageLoader, get_emoji, get_msg
+from .monitor import SchedulerMonitor
+from .setup_wizard import SchedulerSetupWizard
+
+__all__ = [
+    "SchedulerMessageLoader",
+    "get_msg",
+    "get_emoji",
+    "SchedulerDaemonManager",
+    "SchedulerConfigEditor",
+    "SchedulerMonitor",
+    "SchedulerSetupWizard",
+]

--- a/src/cli/scheduler/config_editor.py
+++ b/src/cli/scheduler/config_editor.py
@@ -1,0 +1,252 @@
+"""
+Scheduler config editor - interactive configuration editing.
+
+Provides validation and persistence for scheduler configuration.
+Extracted from scheduler_cli.py (Issue #440).
+"""
+
+import json
+import logging
+import os
+from datetime import time as dt_time
+from typing import Any, Dict, Optional
+
+import yaml
+
+from .message_loader import get_emoji
+
+logger = logging.getLogger(__name__)
+
+
+class SchedulerConfigEditor:
+    """
+    Interactive scheduler configuration editor.
+
+    Handles:
+    - Loading config from YAML/JSON
+    - Interactive editing with validation
+    - Saving config changes
+    - Default configuration generation
+    """
+
+    # Default configuration values
+    DEFAULT_CONFIG = {
+        "enabled": True,
+        "market_timezone": "America/New_York",
+        "morning_routine_time": "09:20:00",
+        "evening_routine_time": "15:50:00",
+        "max_retries": 3,
+        "retry_delay_seconds": 60,
+        "timeout_seconds": 300,
+        "enable_notifications": False,
+        "dry_run": False,
+    }
+
+    def __init__(self, config_file: str = None):
+        """
+        Initialize config editor.
+
+        Args:
+            config_file: Path to config file. Auto-detects YAML/JSON if not provided.
+        """
+        if config_file:
+            self.config_file = config_file
+        else:
+            # Check for YAML first, fallback to JSON
+            yaml_path = "config_defaults/scheduler_config.yaml"
+            json_path = "config_defaults/scheduler_config.json"
+            self.config_file = yaml_path if os.path.exists(yaml_path) else json_path
+
+    def load(self) -> Dict[str, Any]:
+        """
+        Load configuration from file.
+
+        Returns:
+            Configuration dictionary
+        """
+        if not os.path.exists(self.config_file):
+            return self.DEFAULT_CONFIG.copy()
+
+        try:
+            with open(self.config_file, "r", encoding="utf-8") as f:
+                if self.config_file.endswith((".yaml", ".yml")):
+                    return yaml.safe_load(f) or self.DEFAULT_CONFIG.copy()
+                else:
+                    return json.load(f)
+        except Exception as e:
+            logger.warning(f"Error loading config: {e}")
+            return self.DEFAULT_CONFIG.copy()
+
+    def save(self, config: Dict[str, Any]) -> bool:
+        """
+        Save configuration to file.
+
+        Args:
+            config: Configuration dictionary to save
+
+        Returns:
+            True if saved successfully
+        """
+        try:
+            os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
+
+            with open(self.config_file, "w", encoding="utf-8") as f:
+                if self.config_file.endswith((".yaml", ".yml")):
+                    yaml.safe_dump(config, f, default_flow_style=False, sort_keys=False)
+                else:
+                    json.dump(config, f, indent=2)
+            return True
+        except Exception as e:
+            logger.error(f"Error saving config: {e}")
+            return False
+
+    def validate_time(self, time_str: str) -> Optional[str]:
+        """
+        Validate time string format.
+
+        Args:
+            time_str: Time string to validate (HH:MM:SS or HH:MM)
+
+        Returns:
+            Normalized time string (HH:MM:SS) or None if invalid
+        """
+        try:
+            # Handle various formats
+            if len(time_str.split(":")) == 2:
+                time_str = f"{time_str}:00"
+
+            dt_time.fromisoformat(time_str)
+            return time_str
+        except ValueError:
+            return None
+
+    def validate_retries(self, value: str) -> Optional[int]:
+        """
+        Validate retry count.
+
+        Args:
+            value: String value to validate
+
+        Returns:
+            Integer retries (1-10) or None if invalid
+        """
+        try:
+            retries = int(value)
+            if 1 <= retries <= 10:
+                return retries
+        except ValueError:
+            pass
+        return None
+
+    async def edit_interactive(self, scheduler=None) -> Optional[Dict[str, Any]]:  # noqa: C901
+        """
+        Run interactive configuration editor.
+
+        Args:
+            scheduler: Optional scheduler instance to reload after save
+
+        Returns:
+            Updated configuration or None if cancelled
+        """
+        print(f"\n{get_emoji('pencil', '📝')} Scheduler Configuration Editor")
+        print("=" * 70)
+
+        config = self.load()
+
+        print("\nCurrent settings:")
+        print(f"  1. Enabled: {config.get('enabled', True)}")
+        print(f"  2. Morning routine: {config.get('morning_routine_time', '09:20:00')}")
+        print(f"  3. Evening routine: {config.get('evening_routine_time', '15:50:00')}")
+        print(f"  4. Max retries: {config.get('max_retries', 3)}")
+        print(f"  5. Dry run mode: {config.get('dry_run', False)}")
+        print("  0. Save and exit")
+        print("  q. Cancel")
+
+        while True:
+            choice = input("\nEdit setting (1-5, 0 to save, q to cancel): ").strip()
+
+            if choice == "q":
+                print("Cancelled")
+                return None
+            elif choice == "0":
+                if self.save(config):
+                    print(f"{get_emoji('check_green', '✅')} Configuration saved!")
+
+                    if scheduler:
+                        print(f"{get_emoji('refresh', '🔄')} Reloading scheduler...")
+                        try:
+                            from src.trading.daily_scheduler import DailyScheduler
+
+                            existing_cycle = scheduler.trading_cycle
+                            scheduler = DailyScheduler(
+                                self.config_file, trading_cycle=existing_cycle
+                            )
+                            print(f"{get_emoji('check_green', '✅')} Scheduler reloaded")
+                        except Exception as e:
+                            print(f"{get_emoji('warning', '⚠️')} Could not reload: {e}")
+                else:
+                    print(f"{get_emoji('cross_red', '❌')} Failed to save configuration")
+
+                return config
+
+            elif choice == "1":
+                value = input("Enable scheduler? (yes/no): ").strip().lower()
+                config["enabled"] = value in ["yes", "y", "true"]
+
+            elif choice == "2":
+                value = input("Morning routine time (HH:MM:SS): ").strip()
+                validated = self.validate_time(value)
+                if validated:
+                    config["morning_routine_time"] = validated
+                else:
+                    print(f"{get_emoji('cross_red', '❌')} Invalid time format. Use HH:MM:SS")
+
+            elif choice == "3":
+                value = input("Evening routine time (HH:MM:SS): ").strip()
+                validated = self.validate_time(value)
+                if validated:
+                    config["evening_routine_time"] = validated
+                else:
+                    print(f"{get_emoji('cross_red', '❌')} Invalid time format. Use HH:MM:SS")
+
+            elif choice == "4":
+                value = input("Max retries (1-10): ").strip()
+                validated = self.validate_retries(value)
+                if validated:
+                    config["max_retries"] = validated
+                else:
+                    print(f"{get_emoji('cross_red', '❌')} Value must be between 1 and 10")
+
+            elif choice == "5":
+                value = input("Enable dry run mode? (yes/no): ").strip().lower()
+                config["dry_run"] = value in ["yes", "y", "true"]
+
+            else:
+                print("Invalid choice")
+
+    def set_enabled(self, enabled: bool, scheduler=None) -> bool:
+        """
+        Quick enable/disable scheduler.
+
+        Args:
+            enabled: True to enable, False to disable
+            scheduler: Optional scheduler instance to update
+
+        Returns:
+            True if changed successfully
+        """
+        config = self.load()
+        config["enabled"] = enabled
+
+        if self.save(config):
+            status = "enabled" if enabled else "disabled"
+            emoji = get_emoji("check_green", "✅") if enabled else get_emoji("cross_red", "❌")
+            print(f"\n{emoji} Scheduler {status}")
+
+            if scheduler:
+                scheduler.config["enabled"] = enabled
+
+            return True
+
+        print(f"{get_emoji('cross_red', '❌')} Failed to update config")
+        return False

--- a/src/cli/scheduler/daemon_manager.py
+++ b/src/cli/scheduler/daemon_manager.py
@@ -1,0 +1,237 @@
+"""
+Scheduler daemon manager - cross-platform process management.
+
+Handles starting, stopping, and monitoring the scheduler daemon process.
+Extracted from scheduler_cli.py (Issue #440).
+"""
+
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+from .message_loader import get_emoji
+
+logger = logging.getLogger(__name__)
+
+
+class SchedulerDaemonManager:
+    """
+    Cross-platform daemon lifecycle management.
+
+    Handles:
+    - Starting daemon in background
+    - Stopping daemon gracefully
+    - Checking daemon status
+    - PID file management
+    """
+
+    def __init__(self, pid_file: Path = None, main_script: Path = None):
+        """
+        Initialize daemon manager.
+
+        Args:
+            pid_file: Path to PID file. Defaults to state/scheduler.pid
+            main_script: Path to main.py. Auto-detected if not provided.
+        """
+        self.pid_file = pid_file or Path("state/scheduler.pid")
+        self.main_script = main_script or self._find_main_script()
+
+    def _find_main_script(self) -> Path:
+        """Find main.py script path."""
+        # Try relative to this file first
+        main_py = Path(__file__).parent.parent.parent.parent / "main.py"
+        if main_py.exists():
+            return main_py
+
+        # Try current directory
+        main_py = Path("main.py")
+        if main_py.exists():
+            return main_py
+
+        return Path("main.py")  # Default, may not exist
+
+    def is_running(self) -> bool:
+        """
+        Check if scheduler daemon is running.
+
+        Uses psutil if available, falls back to PID file check.
+
+        Returns:
+            True if daemon is running
+        """
+        # Try psutil first (more reliable)
+        try:
+            import psutil
+
+            for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+                try:
+                    cmdline = proc.info.get("cmdline", [])
+                    if cmdline and "main.py" in " ".join(cmdline) and "--daemon" in cmdline:
+                        return True
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.debug(f"psutil check failed: {e}")
+
+        # Fallback: Check PID file
+        if self.pid_file.exists():
+            try:
+                pid = int(self.pid_file.read_text().strip())
+                os.kill(pid, 0)  # Signal 0 = check if process exists
+                return True
+            except (OSError, ValueError):
+                pass
+
+        return False
+
+    def get_pid(self) -> Optional[int]:
+        """
+        Get the daemon PID if running.
+
+        Returns:
+            PID or None if not running
+        """
+        if not self.pid_file.exists():
+            return None
+
+        try:
+            pid = int(self.pid_file.read_text().strip())
+            os.kill(pid, 0)  # Verify process exists
+            return pid
+        except (OSError, ValueError):
+            return None
+
+    def start(self) -> bool:
+        """
+        Start the scheduler daemon in background.
+
+        Returns:
+            True if started successfully
+        """
+        print(f"\n{get_emoji('rocket', '🚀')} Starting Scheduler Daemon...")
+
+        if self.is_running():
+            print(f"{get_emoji('warning', '⚠️')} Scheduler daemon is already running!")
+            print("   Use 'stop' to stop it first, or 'status' to check")
+            return False
+
+        if not self.main_script.exists():
+            print(f"{get_emoji('cross_red', '❌')} main.py not found at: {self.main_script}")
+            return False
+
+        try:
+            python_exe = sys.executable
+
+            if os.name == "nt":  # Windows
+                subprocess.Popen(
+                    [python_exe, str(self.main_script), "--daemon"],
+                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            else:  # Unix/Linux/Mac
+                subprocess.Popen(
+                    [python_exe, str(self.main_script), "--daemon"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+
+            # Wait and verify
+            time.sleep(2)
+
+            if self.is_running():
+                print(f"{get_emoji('check_green', '✅')} Scheduler daemon started successfully!")
+                print("   Use 'status' to see details")
+                print("   Use 'stop' to stop it later")
+                return True
+            else:
+                print(f"{get_emoji('warning', '⚠️')} Daemon may have started but couldn't verify")
+                print("   Check logs with 'logs' command")
+                return False
+
+        except Exception as e:
+            print(f"{get_emoji('cross_red', '❌')} Failed to start daemon: {e}")
+            print("   Try running manually: python main.py --daemon")
+            logger.error(f"Failed to start daemon: {e}", exc_info=True)
+            return False
+
+    def stop(self) -> bool:  # noqa: C901
+        """
+        Stop the scheduler daemon gracefully.
+
+        Returns:
+            True if stopped successfully
+        """
+        print(f"\n{get_emoji('stop', '🛑')} Stopping Scheduler Daemon...")
+
+        if not self.is_running():
+            print(f"{get_emoji('info', 'ℹ️')} Scheduler daemon is not running")
+            return True
+
+        pid = self.get_pid()
+        if pid is None:
+            # Try to find via psutil
+            try:
+                import psutil
+
+                for proc in psutil.process_iter(["pid", "cmdline"]):
+                    try:
+                        cmdline = proc.info.get("cmdline", [])
+                        if cmdline and "main.py" in " ".join(cmdline) and "--daemon" in cmdline:
+                            pid = proc.info["pid"]
+                            break
+                    except (psutil.NoSuchProcess, psutil.AccessDenied):
+                        continue
+            except ImportError:
+                pass
+
+        if pid is None:
+            print(f"{get_emoji('warning', '⚠️')} Could not find daemon PID")
+            print("   Check running processes for 'main.py --daemon'")
+            return False
+
+        try:
+            if os.name == "nt":  # Windows
+                import signal
+
+                os.kill(pid, signal.SIGTERM)
+            else:  # Unix
+                os.kill(pid, 15)  # SIGTERM
+
+            # Wait and verify
+            time.sleep(2)
+
+            if not self.is_running():
+                print(f"{get_emoji('check_green', '✅')} Scheduler daemon stopped successfully!")
+                # Clean up PID file
+                if self.pid_file.exists():
+                    self.pid_file.unlink(missing_ok=True)
+                return True
+            else:
+                print(f"{get_emoji('warning', '⚠️')} Daemon may still be running")
+                print(f"   Try: kill -9 {pid}")
+                return False
+
+        except OSError as e:
+            print(f"{get_emoji('warning', '⚠️')} Could not stop daemon: {e}")
+            print("   You may need to kill the process manually")
+            return False
+
+    def restart(self) -> bool:
+        """
+        Restart the scheduler daemon.
+
+        Returns:
+            True if restarted successfully
+        """
+        print(f"\n{get_emoji('refresh', '🔄')} Restarting Scheduler Daemon...")
+        self.stop()
+        time.sleep(1)
+        return self.start()

--- a/src/cli/scheduler/message_loader.py
+++ b/src/cli/scheduler/message_loader.py
@@ -1,0 +1,154 @@
+"""
+Scheduler message loader - loads CLI messages from YAML configuration.
+
+Reusable utility for loading messages from config files with dot-notation access.
+Extracted from scheduler_cli.py (Issue #440).
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class SchedulerMessageLoader:
+    """
+    Load and access CLI messages from YAML configuration.
+
+    Provides dot-notation access to hierarchical message structures
+    and caches loaded messages for performance.
+    """
+
+    def __init__(self, config_path: Path = None):
+        """
+        Initialize message loader.
+
+        Args:
+            config_path: Path to YAML config file. Defaults to scheduler_cli_messages.yaml
+        """
+        if config_path is None:
+            config_path = (
+                Path(__file__).parent.parent.parent.parent
+                / "config_defaults"
+                / "scheduler_cli_messages.yaml"
+            )
+        self._config_path = config_path
+        self._messages: Dict[str, Any] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Load messages from YAML file."""
+        try:
+            with open(self._config_path, "r", encoding="utf-8") as f:
+                self._messages = yaml.safe_load(f) or {}
+        except Exception as e:
+            logger.warning(f"Could not load scheduler messages from YAML: {e}")
+            self._messages = {}
+
+    def get(self, path: str, default: str = "", **kwargs) -> str:
+        """
+        Get a message by dot-notation path.
+
+        Args:
+            path: Dot-notation path like "welcome.title" or "status.header"
+            default: Default value if path not found
+            **kwargs: Format arguments for the message
+
+        Returns:
+            Formatted message string
+        """
+        keys = path.split(".")
+        value = self._messages
+
+        for key in keys:
+            if isinstance(value, dict) and key in value:
+                value = value[key]
+            else:
+                return default
+
+        if isinstance(value, str):
+            try:
+                return value.format(**kwargs) if kwargs else value
+            except KeyError:
+                return value
+
+        return str(value) if value else default
+
+    def get_emoji(self, name: str, default: str = "") -> str:
+        """
+        Get an emoji by name from the emoji section.
+
+        Args:
+            name: Emoji name (e.g., "check_green", "cross_red")
+            default: Default emoji if not found
+
+        Returns:
+            Emoji string
+        """
+        return self.get(f"emoji.{name}", default)
+
+    def get_dict(self, path: str = "") -> Dict[str, Any]:
+        """
+        Get a dictionary section from messages.
+
+        Args:
+            path: Optional dot-notation path to nested dict
+
+        Returns:
+            Dictionary of messages
+        """
+        if not path:
+            return self._messages
+
+        keys = path.split(".")
+        value = self._messages
+
+        for key in keys:
+            if isinstance(value, dict) and key in value:
+                value = value[key]
+            else:
+                return {}
+
+        return value if isinstance(value, dict) else {}
+
+    def reload(self) -> None:
+        """Reload messages from file."""
+        self._load()
+
+
+# Module-level singleton and convenience functions
+_loader: SchedulerMessageLoader = None
+
+
+def _get_loader() -> SchedulerMessageLoader:
+    """Get or create the module-level loader singleton."""
+    global _loader
+    if _loader is None:
+        _loader = SchedulerMessageLoader()
+    return _loader
+
+
+def get_msg(path: str, default: str = "", **kwargs) -> str:
+    """
+    Get a message by dot-notation path.
+
+    Convenience function using module-level loader.
+    """
+    return _get_loader().get(path, default, **kwargs)
+
+
+def get_emoji(name: str, default: str = "") -> str:
+    """
+    Get an emoji by name.
+
+    Convenience function using module-level loader.
+    """
+    return _get_loader().get_emoji(name, default)
+
+
+def get_messages() -> Dict[str, Any]:
+    """Get all messages dictionary."""
+    return _get_loader().get_dict()

--- a/src/cli/scheduler/monitor.py
+++ b/src/cli/scheduler/monitor.py
@@ -1,0 +1,345 @@
+"""
+Scheduler monitor - status, history, and log displays.
+
+Provides monitoring views for scheduler status and execution history.
+Extracted from scheduler_cli.py (Issue #440).
+"""
+
+import logging
+from datetime import time as dt_time
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from .daemon_manager import SchedulerDaemonManager
+from .message_loader import get_emoji, get_messages
+from src.utils.date_utils import get_datetime_now
+
+if TYPE_CHECKING:
+    from src.trading.daily_scheduler import DailyScheduler
+
+logger = logging.getLogger(__name__)
+
+
+class SchedulerMonitor:
+    """
+    Scheduler monitoring and status display.
+
+    Provides:
+    - Status overview
+    - Configuration info
+    - Execution history
+    - Log viewing
+    - Next run calculation
+    """
+
+    def __init__(self, scheduler: Optional["DailyScheduler"] = None):
+        """
+        Initialize monitor.
+
+        Args:
+            scheduler: Optional scheduler instance for status queries
+        """
+        self.scheduler = scheduler
+        self.daemon_manager = SchedulerDaemonManager()
+
+    def show_status(self) -> None:
+        """Show detailed scheduler status."""
+        print(f"\n{get_emoji('clock', '⏰')} Scheduler Status")
+        print("=" * 70)
+
+        if not self.scheduler:
+            print(f"{get_emoji('cross_red', '❌')} Scheduler not initialized")
+            return
+
+        # Check daemon status
+        daemon_running = self.daemon_manager.is_running()
+        enabled = self.scheduler.config.get("enabled", False)
+
+        # Config status
+        config_emoji = get_emoji("green_circle", "🟢") if enabled else get_emoji("red_circle", "🔴")
+        print(f"\n{config_emoji} Config: {'ENABLED' if enabled else 'DISABLED'}")
+
+        # Daemon/service status
+        if daemon_running:
+            print(f"{get_emoji('check_green', '✅')} Service: RUNNING (automatic execution active)")
+        else:
+            print(f"{get_emoji('cross_red', '❌')} Service: NOT RUNNING (no automatic execution)")
+            if enabled:
+                print(f"\n{get_emoji('light', '💡')} Config is enabled but daemon is not running.")
+                print("   To start automatic execution:")
+                print("   1. Exit this CLI")
+                print("   2. Run: python main.py --daemon")
+                print("   3. Scheduler will run automatically at scheduled times")
+                print("\n   Or use 'test morning/evening' to run manually now")
+
+        # Configuration details
+        print(f"\n{get_emoji('gear', '⚙️')} Configuration:")
+        print(f"   Morning: {self.scheduler.config.get('morning_routine_time', 'N/A')} ET")
+        print(f"   Evening: {self.scheduler.config.get('evening_routine_time', 'N/A')} ET")
+        print(f"   Timezone: {self.scheduler.config.get('market_timezone', 'N/A')}")
+        print(f"   Max Retries: {self.scheduler.config.get('max_retries', 3)}")
+        print(f"   Dry Run: {self.scheduler.config.get('dry_run', False)}")
+
+        # Recent executions
+        recent = self.scheduler.get_execution_history(days=1)
+        if recent:
+            print(f"\n{get_emoji('clipboard', '📋')} Today's Executions: {len(recent)}")
+            for entry in recent[:5]:
+                status = (
+                    get_emoji("check_green", "✅")
+                    if entry.status == "completed"
+                    else get_emoji("cross_red", "❌")
+                )
+                print(f"   {status} {entry.task_name} - {entry.status}")
+        else:
+            print(f"\n{get_emoji('clipboard', '📋')} No executions today")
+            if enabled and not daemon_running:
+                print("   (Daemon not running - no automatic executions)")
+
+    def show_config(self, config_file: str = None) -> None:
+        """
+        Display current scheduler configuration file.
+
+        Args:
+            config_file: Path to config file
+        """
+        if config_file is None:
+            config_file = "config_defaults/scheduler_config.yaml"
+
+        print(f"\n{get_emoji('gear', '⚙️')} Scheduler Configuration")
+        print("=" * 70)
+
+        config_path = Path(config_file)
+        if config_path.exists():
+            print(f"\nConfig file: {config_file}\n")
+            print(config_path.read_text())
+        else:
+            print(f"{get_emoji('cross_red', '❌')} Config file not found: {config_file}")
+            print(f"{get_emoji('light', '💡')} Will be created with defaults on first run")
+
+    def show_config_info(self) -> None:  # noqa: C901
+        """Display detailed explanations for configuration settings."""
+        info = get_messages().get("config_info", {})
+        settings = info.get("settings", {})
+
+        # Header
+        print(f"\n{get_emoji('book', '📖')} {info.get('header', 'Scheduler Configuration Guide')}")
+        print("=" * 70)
+
+        # Editable settings
+        print(f"\n{get_emoji('wrench', '🔧')} {info.get('editable_header', 'EDITABLE SETTINGS')}")
+        print("-" * 70)
+
+        setting_order = ["enabled", "morning_time", "evening_time", "max_retries", "dry_run"]
+        config_keys = {
+            "enabled": "enabled",
+            "morning_time": "morning_routine_time",
+            "evening_time": "evening_routine_time",
+            "max_retries": "max_retries",
+            "dry_run": "dry_run",
+        }
+
+        for i, setting_key in enumerate(setting_order, 1):
+            setting = settings.get(setting_key, {})
+            if not setting:
+                continue
+
+            config_key = config_keys.get(setting_key, setting_key)
+            current = self.scheduler.config.get(config_key, "N/A") if self.scheduler else "N/A"
+
+            print(f"\n{i}. {setting.get('name', setting_key)}")
+            print(f"   Current: {current}")
+            print(f"   Purpose: {setting.get('purpose', '')}")
+
+            if "default" in setting:
+                print(f"   Default: {setting['default']}")
+
+            for val in setting.get("values", []):
+                print(f"   Values:  {val}")
+
+            if "warning" in setting:
+                print(f"   {get_emoji('warning', '⚠️')} NOTE: {setting['warning']}")
+
+            if "status" in setting:
+                print(f"   Status:  {setting['status']}")
+
+            if "tip" in setting:
+                print(f"   Tip:     {setting['tip']}")
+
+        # Read-only settings
+        print(
+            f"\n\n{get_emoji('clipboard', '📋')} {info.get('readonly_header', 'READ-ONLY SETTINGS')}"
+        )
+        print("-" * 70)
+
+        for setting in info.get("readonly_settings", []):
+            print(f"\n• {setting.get('name', '')}: {setting.get('value', '')}")
+            print(f"  {setting.get('description', '')}")
+
+        # Quick reference
+        qref = info.get("quick_reference", {})
+        print(f"\n\n{get_emoji('light', '💡')} {qref.get('header', 'QUICK REFERENCE')}")
+        print("-" * 70)
+
+        paper_dry = qref.get("paper_vs_dry", {})
+        if paper_dry:
+            print(f"\n{paper_dry.get('title', '')}:")
+            for item in paper_dry.get("items", []):
+                print(f"  • {item}")
+
+        safety = qref.get("safety_levels", {})
+        if safety:
+            print(f"\n{safety.get('title', '')}:")
+            for item in safety.get("items", []):
+                print(f"  {item}")
+
+        issues = qref.get("related_issues", {})
+        if issues:
+            print(f"\n{issues.get('title', '')}:")
+            for item in issues.get("items", []):
+                print(f"  • {item}")
+
+        print("\n" + "=" * 70)
+        print(info.get("footer", "Type 'edit' to modify settings or 'config' to view raw file"))
+        print("")
+
+    def show_history(self, days: int = 7, limit: int = 20) -> None:
+        """
+        Show execution history.
+
+        Args:
+            days: Number of days to look back
+            limit: Maximum entries to show
+        """
+        if not self.scheduler:
+            print(f"{get_emoji('cross_red', '❌')} Scheduler not initialized")
+            return
+
+        print(f"\n{get_emoji('scroll', '📜')} Execution History")
+        print("=" * 70)
+
+        history = self.scheduler.get_execution_history(days=days)
+
+        if not history:
+            print("No execution history found")
+            return
+
+        print(f"\nShowing last {limit} executions ({days} days):\n")
+
+        for entry in history[:limit]:
+            status_emoji = (
+                get_emoji("check_green", "✅")
+                if entry.status == "completed"
+                else get_emoji("cross_red", "❌")
+            )
+            time_str = (
+                entry.actual_end_time.strftime("%Y-%m-%d %H:%M")
+                if entry.actual_end_time
+                else "In Progress"
+            )
+
+            print(f"{status_emoji} {entry.task_name:20s} {entry.status:12s} {time_str}")
+            if entry.error_message:
+                print(f"   {get_emoji('warning', '⚠️')} {entry.error_message[:60]}...")
+
+    def show_next_run(self) -> None:
+        """Calculate and show next scheduled run."""
+        if not self.scheduler:
+            print(f"{get_emoji('cross_red', '❌')} Scheduler not initialized")
+            return
+
+        print(f"\n{get_emoji('crystal_ball', '🔮')} Next Scheduled Run")
+        print("=" * 70)
+
+        try:
+            from datetime import timedelta
+
+            import pytz
+
+            et = pytz.timezone("US/Eastern")
+            now = get_datetime_now(et)
+
+            morning_time = dt_time.fromisoformat(self.scheduler.config["morning_routine_time"])
+            evening_time = dt_time.fromisoformat(self.scheduler.config["evening_routine_time"])
+
+            morning_today = now.replace(
+                hour=morning_time.hour, minute=morning_time.minute, second=0, microsecond=0
+            )
+            evening_today = now.replace(
+                hour=evening_time.hour, minute=evening_time.minute, second=0, microsecond=0
+            )
+
+            if now.time() < morning_time:
+                next_run = morning_today
+                next_task = "Morning Routine"
+            elif now.time() < evening_time:
+                next_run = evening_today
+                next_task = "Evening Routine"
+            else:
+                next_run = morning_today + timedelta(days=1)
+                next_task = "Morning Routine (tomorrow)"
+
+            time_until = next_run - now
+            hours = int(time_until.total_seconds() // 3600)
+            minutes = int((time_until.total_seconds() % 3600) // 60)
+
+            print(f"\n{get_emoji('clock', '⏰')} {next_task}")
+            print(f"   Time: {next_run.strftime('%H:%M %p')} ET")
+            print(f"   Countdown: {hours}h {minutes}m")
+            print(f"   Date: {next_run.strftime('%Y-%m-%d')}")
+
+        except Exception as e:
+            print(f"{get_emoji('cross_red', '❌')} Error calculating next run: {e}")
+
+    def show_logs(self, lines: int = 50) -> None:
+        """
+        Show recent scheduler logs.
+
+        Args:
+            lines: Number of log lines to show
+        """
+        print(f"\n{get_emoji('scroll', '📜')} Recent Scheduler Logs")
+        print("=" * 70)
+
+        log_paths = [
+            Path("logs/scheduler.log"),
+            Path("logs/autotrader.log"),
+            Path("state/scheduler_history.json"),
+        ]
+
+        log_file = None
+        for path in log_paths:
+            if path.exists():
+                log_file = path
+                break
+
+        if not log_file:
+            print(f"{get_emoji('info', 'ℹ️')} No log files found")
+            print("   Logs are created when the scheduler runs")
+            print("   Try 'test morning' or 'start' first")
+            return
+
+        print(f"\nShowing last {lines} lines from: {log_file}\n")
+        print("-" * 70)
+
+        try:
+            with open(log_file, "r") as f:
+                all_lines = f.readlines()
+                recent = all_lines[-lines:] if len(all_lines) > lines else all_lines
+
+                for line in recent:
+                    line_lower = line.lower()
+                    if "error" in line_lower:
+                        print(f"{get_emoji('cross_red', '❌')} {line.rstrip()}")
+                    elif "warning" in line_lower or "warn" in line_lower:
+                        print(f"{get_emoji('warning', '⚠️')} {line.rstrip()}")
+                    elif "success" in line_lower or "completed" in line_lower:
+                        print(f"{get_emoji('check_green', '✅')} {line.rstrip()}")
+                    else:
+                        print(f"   {line.rstrip()}")
+
+        except Exception as e:
+            print(f"{get_emoji('cross_red', '❌')} Error reading logs: {e}")
+
+        print("-" * 70)
+        print(f"\n{get_emoji('light', '💡')} Full logs at: {log_file}")

--- a/src/cli/scheduler/setup_wizard.py
+++ b/src/cli/scheduler/setup_wizard.py
@@ -1,0 +1,188 @@
+"""
+Scheduler setup wizard - first-time setup flow for layman users.
+
+Guides users through initial scheduler configuration.
+Extracted from scheduler_cli.py (Issue #440, implements #338).
+"""
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from .config_editor import SchedulerConfigEditor
+from .daemon_manager import SchedulerDaemonManager
+from .message_loader import get_emoji
+
+if TYPE_CHECKING:
+    from src.trading.daily_scheduler import DailyScheduler
+
+logger = logging.getLogger(__name__)
+
+
+class SchedulerSetupWizard:
+    """
+    First-time setup wizard for scheduler configuration.
+
+    Guides users through:
+    1. Welcome and explanation
+    2. Schedule frequency selection
+    3. Time configuration
+    4. Save and optionally start daemon
+    """
+
+    def __init__(self, scheduler: Optional["DailyScheduler"] = None):
+        """
+        Initialize setup wizard.
+
+        Args:
+            scheduler: Optional existing scheduler instance
+        """
+        self.scheduler = scheduler
+        self.config_editor = SchedulerConfigEditor()
+        self.daemon_manager = SchedulerDaemonManager()
+
+    async def run(self) -> Optional[Dict[str, Any]]:  # noqa: C901
+        """
+        Run the setup wizard.
+
+        Returns:
+            Configuration dict if completed, None if cancelled
+        """
+        print("\n" + "=" * 70)
+        print(f"   {get_emoji('wizard', '🧙')} Scheduler Setup Wizard")
+        print("=" * 70)
+
+        # Explanation
+        print(f"\n{get_emoji('book', '📖')} What does the scheduler do?")
+        print("   The scheduler automatically runs trading routines at set times:")
+        print("   • Morning routine: Pre-market check, prepare for trading day")
+        print("   • Evening routine: End-of-day review, adjust stops")
+
+        print("\n" + "-" * 70)
+
+        # Step 1: Schedule frequency
+        print("\n1️⃣  How often should the scheduler run?")
+        print("   1. Twice daily (morning + evening) - RECOMMENDED")
+        print("   2. Morning only (pre-market)")
+        print("   3. Evening only (end-of-day)")
+        print("   4. Cancel setup")
+
+        choice = input("\nChoice [1-4]: ").strip()
+
+        if choice == "4":
+            print(f"\n{get_emoji('cross_red', '❌')} Setup cancelled")
+            return None
+
+        enable_morning = choice in ["1", "2"]
+        enable_evening = choice in ["1", "3"]
+
+        # Step 2: Time configuration
+        config = SchedulerConfigEditor.DEFAULT_CONFIG.copy()
+
+        if enable_morning:
+            print("\n2️⃣  Morning routine time (default: 9:20 AM ET, 10 min before market)")
+            print("   Press Enter for default, or enter time like '9:00' or '09:30'")
+            time_input = input("   Morning time: ").strip()
+
+            if time_input:
+                normalized = self._parse_time(time_input)
+                if normalized:
+                    config["morning_routine_time"] = normalized
+                else:
+                    print(f"   {get_emoji('warning', '⚠️')} Invalid format, using default 9:20 AM")
+
+        if enable_evening:
+            print("\n3️⃣  Evening routine time (default: 3:50 PM ET, 10 min before close)")
+            print("   Press Enter for default, or enter time like '15:30' or '3:45'")
+            time_input = input("   Evening time: ").strip()
+
+            if time_input:
+                normalized = self._parse_time(time_input, assume_pm=True)
+                if normalized:
+                    config["evening_routine_time"] = normalized
+                else:
+                    print(f"   {get_emoji('warning', '⚠️')} Invalid format, using default 3:50 PM")
+
+        # Disable routines if not selected
+        if not enable_morning:
+            config["morning_routine_enabled"] = False
+        if not enable_evening:
+            config["evening_routine_enabled"] = False
+
+        config["enabled"] = True
+
+        # Step 3: Summary and save
+        print("\n" + "-" * 70)
+        print(f"\n{get_emoji('clipboard', '📋')} Configuration Summary:")
+
+        morning_status = (
+            f"{get_emoji('check_green', '✅')} Enabled"
+            if enable_morning
+            else f"{get_emoji('cross_red', '❌')} Disabled"
+        )
+        evening_status = (
+            f"{get_emoji('check_green', '✅')} Enabled"
+            if enable_evening
+            else f"{get_emoji('cross_red', '❌')} Disabled"
+        )
+
+        print(f"   Morning routine: {morning_status}")
+        if enable_morning:
+            print(f"      Time: {config.get('morning_routine_time', 'N/A')} ET")
+
+        print(f"   Evening routine: {evening_status}")
+        if enable_evening:
+            print(f"      Time: {config.get('evening_routine_time', 'N/A')} ET")
+
+        confirm = input("\nSave this configuration? [yes/no]: ").strip().lower()
+
+        if confirm in ["yes", "y"]:
+            if self.config_editor.save(config):
+                print(f"\n{get_emoji('check_green', '✅')} Configuration saved!")
+
+                # Offer to start daemon
+                start_now = input("\nStart scheduler now? [yes/no]: ").strip().lower()
+                if start_now in ["yes", "y"]:
+                    self.daemon_manager.start()
+
+                return config
+            else:
+                print(f"\n{get_emoji('cross_red', '❌')} Failed to save configuration")
+                return None
+        else:
+            print(f"\n{get_emoji('cross_red', '❌')} Setup cancelled, configuration not saved")
+            return None
+
+    def _parse_time(self, time_input: str, assume_pm: bool = False) -> Optional[str]:
+        """
+        Parse user time input to HH:MM:SS format.
+
+        Args:
+            time_input: User input like "9:00", "9:30", "15:30"
+            assume_pm: If True, assume PM for hour < 12
+
+        Returns:
+            Normalized time string or None if invalid
+        """
+        try:
+            # Clean input
+            time_input = time_input.replace("am", "").replace("pm", "").strip()
+
+            if ":" not in time_input:
+                return None
+
+            parts = time_input.split(":")
+            hour = int(parts[0])
+            minute = int(parts[1]) if len(parts) > 1 else 0
+
+            # Assume PM for evening times
+            if assume_pm and hour < 12:
+                hour += 12
+
+            # Validate
+            if not (0 <= hour <= 23 and 0 <= minute <= 59):
+                return None
+
+            return f"{hour:02d}:{minute:02d}:00"
+
+        except (ValueError, IndexError):
+            return None

--- a/src/cli/scheduler_cli.py
+++ b/src/cli/scheduler_cli.py
@@ -9,74 +9,25 @@ Provides dedicated commands for:
 - Starting/stopping scheduler service
 
 Messages are loaded from config_defaults/scheduler_cli_messages.yaml
+
+Refactored in Issue #440: Extracted components to src/cli/scheduler/
 """
 
 import asyncio
 import logging
-import os
-from datetime import time as dt_time
-from pathlib import Path
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 
-import yaml
-
+from .scheduler import (
+    SchedulerConfigEditor,
+    SchedulerDaemonManager,
+    SchedulerMonitor,
+    SchedulerSetupWizard,
+    get_emoji,
+)
+from .scheduler.message_loader import get_messages
 from src.trading.daily_scheduler import DailyScheduler
-from src.utils.date_utils import get_datetime_now
 
 logger = logging.getLogger(__name__)
-
-
-def _load_scheduler_messages() -> Dict[str, Any]:
-    """Load scheduler CLI messages from YAML configuration."""
-    config_path = (
-        Path(__file__).parent.parent.parent / "config_defaults" / "scheduler_cli_messages.yaml"
-    )
-
-    try:
-        with open(config_path, "r", encoding="utf-8") as f:
-            return yaml.safe_load(f)
-    except Exception as e:
-        logger.warning(f"Could not load scheduler messages from YAML: {e}")
-        return {}
-
-
-# Load messages at module level
-MSG = _load_scheduler_messages()
-
-
-def _get_msg(path: str, default: str = "", **kwargs) -> str:
-    """
-    Get a message from the config by dot-notation path.
-
-    Args:
-        path: Dot-notation path like "welcome.title" or "status.header"
-        default: Default value if path not found
-        **kwargs: Format arguments for the message
-
-    Returns:
-        Formatted message string
-    """
-    keys = path.split(".")
-    value = MSG
-
-    for key in keys:
-        if isinstance(value, dict) and key in value:
-            value = value[key]
-        else:
-            return default
-
-    if isinstance(value, str):
-        try:
-            return value.format(**kwargs) if kwargs else value
-        except KeyError:
-            return value
-
-    return str(value) if value else default
-
-
-def _get_emoji(name: str, default: str = "") -> str:
-    """Get an emoji from config."""
-    return _get_msg(f"emoji.{name}", default)
 
 
 class SchedulerCLI:
@@ -85,6 +36,13 @@ class SchedulerCLI:
 
     Commands are defined in config_defaults/scheduler_cli_messages.yaml.
     To add/remove/disable commands, edit the 'commands' section in that file.
+
+    Components extracted to src/cli/scheduler/:
+    - SchedulerMessageLoader: Message loading from YAML
+    - SchedulerDaemonManager: Start/stop/status of daemon
+    - SchedulerConfigEditor: Config editing with validation
+    - SchedulerMonitor: Status/history/logs display
+    - SchedulerSetupWizard: First-time setup flow
     """
 
     def __init__(self, scheduler: Optional[DailyScheduler] = None):
@@ -95,12 +53,13 @@ class SchedulerCLI:
             scheduler: Optional existing DailyScheduler instance
         """
         self.scheduler = scheduler
-        self.config_file = "config_defaults/scheduler_config.yaml"
         self._running = True
 
-        # Check for YAML, fallback to JSON
-        if not os.path.exists(self.config_file):
-            self.config_file = "config_defaults/scheduler_config.json"
+        # Initialize extracted components
+        self.config_editor = SchedulerConfigEditor()
+        self.daemon_manager = SchedulerDaemonManager()
+        self.monitor = SchedulerMonitor(scheduler)
+        self.setup_wizard = SchedulerSetupWizard(scheduler)
 
         # Build command registry from config
         self._command_registry = self._build_command_registry()
@@ -113,13 +72,12 @@ class SchedulerCLI:
             Dict mapping command names and aliases to their definitions.
         """
         registry = {}
-        commands = MSG.get("commands", {})
+        commands = get_messages().get("commands", {})
 
         for cmd_name, cmd_def in commands.items():
             if not cmd_def.get("enabled", True):
-                continue  # Skip disabled commands
+                continue
 
-            # Register primary command name
             registry[cmd_name] = {
                 "name": cmd_name,
                 "handler": cmd_def.get("handler", cmd_name),
@@ -129,18 +87,13 @@ class SchedulerCLI:
                 "usage": cmd_def.get("usage", ""),
             }
 
-            # Register aliases
             for alias in cmd_def.get("aliases", []):
                 registry[alias] = registry[cmd_name]
 
         return registry
 
     async def run(self):
-        """
-        Main scheduler CLI loop.
-
-        Commands are routed dynamically based on config.
-        """
+        """Main scheduler CLI loop."""
         self._print_welcome()
 
         while self._running:
@@ -150,36 +103,34 @@ class SchedulerCLI:
                 if not command:
                     continue
 
-                # Strip leading slash for compatibility with main CLI
                 if command.startswith("/"):
                     command = command[1:]
 
-                # Route command through registry
                 await self._handle_command(command)
 
             except KeyboardInterrupt:
-                print(f"\n\n{_get_emoji('wave', '👋')} Exiting scheduler CLI...")
+                print(f"\n\n{get_emoji('wave', '👋')} Exiting scheduler CLI...")
                 break
             except Exception as e:
-                print(f"\n{_get_emoji('cross_red', '❌')} Error: {e}")
+                print(f"\n{get_emoji('cross_red', '❌')} Error: {e}")
                 logger.error(f"Scheduler CLI error: {e}", exc_info=True)
 
     def _print_welcome(self):
         """Print scheduler CLI welcome message with auto-generated command list."""
-        welcome = MSG.get("welcome", {})
-        categories = MSG.get("categories", {})
+        messages = get_messages()
+        welcome = messages.get("welcome", {})
+        categories = messages.get("categories", {})
 
-        # Banner and title
         banner = welcome.get("banner", "=" * 70)
         print("\n" + banner)
         print(
-            f"   {_get_emoji('calendar', '📅')} {welcome.get('title', 'Scheduler Management CLI')}"
+            f"   {get_emoji('calendar', '📅')} {welcome.get('title', 'Scheduler Management CLI')}"
         )
         print(banner)
 
-        # Group enabled commands by category
+        # Group commands by category
         commands_by_category: Dict[str, list] = {}
-        for cmd_name, cmd_def in MSG.get("commands", {}).items():
+        for cmd_name, cmd_def in messages.get("commands", {}).items():
             if not cmd_def.get("enabled", True):
                 continue
             category = cmd_def.get("category", "other")
@@ -193,785 +144,160 @@ class SchedulerCLI:
                 }
             )
 
-        # Sort categories by order
+        # Sort and print categories
         sorted_cats = sorted(categories.items(), key=lambda x: x[1].get("order", 99))
 
-        # Print each category
         for cat_key, cat_def in sorted_cats:
             cmds = commands_by_category.get(cat_key, [])
             if not cmds:
                 continue
 
             emoji_name = cat_def.get("emoji", "")
-            emoji = _get_emoji(emoji_name, "") if emoji_name else ""
+            emoji = get_emoji(emoji_name, "") if emoji_name else ""
             header = cat_def.get("header", cat_key.title())
             print(f"\n{emoji} {header}")
 
             for cmd in cmds:
-                name = cmd["name"]
-                # Use usage if provided (e.g., "test [morning|evening]")
-                display_name = cmd.get("usage") or name
-                desc = cmd["description"]
-                print(f"  {display_name:16s} - {desc}")
+                display_name = cmd.get("usage") or cmd["name"]
+                print(f"  {display_name:16s} - {cmd['description']}")
 
         print("")
 
     async def _handle_command(self, command: str):
-        """
-        Handle scheduler CLI commands using config-driven routing.
-
-        Commands are looked up in the registry (built from YAML config).
-        To add/remove/disable commands, edit scheduler_cli_messages.yaml.
-
-        Args:
-            command: User command string
-        """
-        # Parse command and arguments
+        """Handle scheduler CLI commands using config-driven routing."""
         parts = command.split()
         cmd_name = parts[0] if parts else ""
         args = parts[1:] if len(parts) > 1 else []
 
-        # Look up command in registry
         cmd_def = self._command_registry.get(cmd_name)
 
         if not cmd_def:
-            print(f"{_get_emoji('cross_red', '❌')} Unknown command: {command}")
+            print(f"{get_emoji('cross_red', '❌')} Unknown command: {command}")
             print("Type 'help' for available commands")
             return
 
-        # Initialize scheduler if required by this command
+        # Initialize scheduler if required
         if cmd_def.get("requires_scheduler") and self.scheduler is None:
             try:
                 self.scheduler = DailyScheduler()
+                self.monitor.scheduler = self.scheduler
+                self.setup_wizard.scheduler = self.scheduler
             except Exception as e:
-                print(f"{_get_emoji('cross_red', '❌')} Failed to initialize scheduler: {e}")
-                print(f"{_get_emoji('light', '💡')} Try running: python main.py --daemon")
+                print(f"{get_emoji('cross_red', '❌')} Failed to initialize scheduler: {e}")
+                print(f"{get_emoji('light', '💡')} Try running: python main.py --daemon")
                 return
 
-        # Get handler method
+        # Get and call handler
         handler_name = cmd_def.get("handler", cmd_name)
         handler = getattr(self, f"_{handler_name}", None)
 
         if not handler or not callable(handler):
-            print(f"{_get_emoji('cross_red', '❌')} Handler not implemented: {handler_name}")
+            print(f"{get_emoji('cross_red', '❌')} Handler not implemented: {handler_name}")
             return
 
-        # Call handler (async or sync)
-        handler = cast(Any, handler)  # Type assertion after callable check
         try:
             if asyncio.iscoroutinefunction(handler):
-                await handler(*args)  # pylint: disable=not-callable
+                await handler(*args)
             else:
-                handler(*args)  # pylint: disable=not-callable
-        except TypeError as e:
-            # Wrong number of arguments
+                handler(*args)
+        except TypeError:
             usage = cmd_def.get("usage", "")
             if usage:
                 print(f"Usage: {usage}")
             else:
-                print(f"{_get_emoji('cross_red', '❌')} Error: {e}")
+                raise
 
     # =========================================================================
-    # Handler wrapper methods (for config-driven routing)
+    # Command Handlers - Delegate to extracted components
     # =========================================================================
 
-    def _set_enabled_true(self):
-        """Wrapper for enable command."""
-        self._set_enabled(True)
-
-    def _set_enabled_false(self):
-        """Wrapper for disable command."""
-        self._set_enabled(False)
-
-    def _exit_cli(self):
-        """Exit the scheduler CLI loop."""
-        print(f"\n{_get_emoji('wave', '👋')} Exiting scheduler CLI...")
-        self._running = False
-
-    async def _show_status(self):
-        """Show detailed scheduler status."""
-        print("\n⏰ Scheduler Status")
-        print("=" * 70)
-
-        if not self.scheduler:
-            print("❌ Scheduler not initialized")
-            return
-
-        # Check if daemon is actually running
-        daemon_running = self._is_daemon_running()
-        enabled = self.scheduler.config.get("enabled", False)
-
-        # Config status
-        config_emoji = "🟢" if enabled else "🔴"
-        print(f"\n{config_emoji} Config: {'ENABLED' if enabled else 'DISABLED'}")
-
-        # Daemon/service status (actual execution)
-        if daemon_running:
-            print("✅ Service: RUNNING (automatic execution active)")
-        else:
-            print("❌ Service: NOT RUNNING (no automatic execution)")
-            if enabled:
-                print("\n💡 Config is enabled but daemon is not running.")
-                print("   To start automatic execution:")
-                print("   1. Exit this CLI")
-                print("   2. Run: python main.py --daemon")
-                print("   3. Scheduler will run automatically at scheduled times")
-                print("\n   Or use 'test morning/evening' to run manually now")
-
-        print("\n⚙️  Configuration:")
-        print(f"   Morning: {self.scheduler.config.get('morning_routine_time', 'N/A')} ET")
-        print(f"   Evening: {self.scheduler.config.get('evening_routine_time', 'N/A')} ET")
-        print(f"   Timezone: {self.scheduler.config.get('market_timezone', 'N/A')}")
-        print(f"   Max Retries: {self.scheduler.config.get('max_retries', 3)}")
-        print(f"   Dry Run: {self.scheduler.config.get('dry_run', False)}")
-
-        # Show recent executions
-        recent = self.scheduler.get_execution_history(days=1)
-        if recent:
-            print(f"\n📋 Today's Executions: {len(recent)}")
-            for entry in recent[:5]:
-                status = "✅" if entry.status == "completed" else "❌"
-                print(f"   {status} {entry.task_name} - {entry.status}")
-        else:
-            print("\n📋 No executions today")
-            if enabled and not daemon_running:
-                print("   (Daemon not running - no automatic executions)")
-
-    def _is_daemon_running(self) -> bool:
-        """Check if scheduler daemon is actually running."""
-        # Try psutil first (if available)
-        try:
-            import psutil
-
-            # Check for process running main.py --daemon
-            for proc in psutil.process_iter(["pid", "name", "cmdline"]):
-                try:
-                    cmdline = proc.info.get("cmdline", [])
-                    if cmdline and "main.py" in " ".join(cmdline) and "--daemon" in cmdline:
-                        return True
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
-                    continue
-        except (ImportError, Exception):
-            # psutil not installed or error, use PID file fallback
-            pass
-
-        # Fallback: Check PID file
-        pid_file = Path("state/scheduler.pid")
-        if pid_file.exists():
-            try:
-                pid = int(pid_file.read_text())
-                os.kill(pid, 0)  # Check if process exists (0 = no signal, just check)
-                return True
-            except (OSError, ValueError):
-                # Process doesn't exist or PID file corrupted
-                pass
-
-        return False
+    def _show_status(self):
+        """Show scheduler status."""
+        self.monitor.show_status()
 
     def _show_config(self):
-        """Display current scheduler configuration."""
-        print("\n⚙️  Scheduler Configuration")
-        print("=" * 70)
-
-        if os.path.exists(self.config_file):
-            print(f"\nConfig file: {self.config_file}\n")
-            with open(self.config_file, "r") as f:
-                content = f.read()
-                print(content)
-        else:
-            print(f"❌ Config file not found: {self.config_file}")
-            print("💡 Will be created with defaults on first run")
+        """Show configuration file."""
+        self.monitor.show_config(self.config_editor.config_file)
 
     def _show_config_info(self):
-        """Display explanations for configuration settings from config."""
-        info = MSG.get("config_info", {})
-        settings = info.get("settings", {})
-
-        # Header
-        print(f"\n{_get_emoji('book', '📖')} {info.get('header', 'Scheduler Configuration Guide')}")
-        print("=" * 70)
-
-        # Editable settings section
-        print(f"\n🔧 {info.get('editable_header', 'EDITABLE SETTINGS')}")
-        print("-" * 70)
-
-        # Map setting names to config keys for current value lookup
-        setting_order = ["enabled", "morning_time", "evening_time", "max_retries", "dry_run"]
-        config_keys = {
-            "enabled": "enabled",
-            "morning_time": "morning_routine_time",
-            "evening_time": "evening_routine_time",
-            "max_retries": "max_retries",
-            "dry_run": "dry_run",
-        }
-
-        for i, setting_key in enumerate(setting_order, 1):
-            setting = settings.get(setting_key, {})
-            if not setting:
-                continue
-
-            config_key = config_keys.get(setting_key, setting_key)
-            current = self.scheduler.config.get(config_key, "N/A") if self.scheduler else "N/A"
-
-            print(f"\n{i}. {setting.get('name', setting_key)}")
-            print(f"   Current: {current}")
-            print(f"   Purpose: {setting.get('purpose', '')}")
-
-            if "default" in setting:
-                print(f"   Default: {setting['default']}")
-
-            for val in setting.get("values", []):
-                print(f"   Values:  {val}")
-
-            if "warning" in setting:
-                print(f"   {_get_emoji('warning', '⚠️')}  NOTE: {setting['warning']}")
-
-            if "status" in setting:
-                print(f"   Status:  {setting['status']}")
-
-            if "tip" in setting:
-                print(f"   Tip:     {setting['tip']}")
-
-        # Read-only settings section
-        readonly_header = info.get("readonly_header", "READ-ONLY SETTINGS")
-        print(f"\n\n{_get_emoji('clipboard', '📋')} {readonly_header}")
-        print("-" * 70)
-
-        for setting in info.get("readonly_settings", []):
-            print(f"\n• {setting.get('name', '')}: {setting.get('value', '')}")
-            print(f"  {setting.get('description', '')}")
-
-        # Quick reference section
-        qref = info.get("quick_reference", {})
-        print(f"\n\n{_get_emoji('light', '💡')} {qref.get('header', 'QUICK REFERENCE')}")
-        print("-" * 70)
-
-        # Paper vs Dry Run
-        paper_dry = qref.get("paper_vs_dry", {})
-        if paper_dry:
-            print(f"\n{paper_dry.get('title', '')}:")
-            for item in paper_dry.get("items", []):
-                print(f"  • {item}")
-
-        # Safety Levels
-        safety = qref.get("safety_levels", {})
-        if safety:
-            print(f"\n{safety.get('title', '')}:")
-            for item in safety.get("items", []):
-                print(f"  {item}")
-
-        # Related Issues
-        issues = qref.get("related_issues", {})
-        if issues:
-            print(f"\n{issues.get('title', '')}:")
-            for item in issues.get("items", []):
-                print(f"  • {item}")
-
-        print("\n" + "=" * 70)
-        print(info.get("footer", "Type 'edit' to modify settings or 'config' to view raw file"))
-        print("")
+        """Show configuration info/guide."""
+        self.monitor.show_config_info()
 
     async def _edit_config(self):
-        """Interactive configuration editor."""
-        print("\n📝 Scheduler Configuration Editor")
-        print("=" * 70)
+        """Interactive config editor."""
+        await self.config_editor.edit_interactive(self.scheduler)
 
-        # Load current config
-        if os.path.exists(self.config_file):
-            with open(self.config_file, "r") as f:
-                if self.config_file.endswith(".yaml") or self.config_file.endswith(".yml"):
-                    if yaml is None:
-                        print("❌ PyYAML not installed. Install with: pip install pyyaml")
-                        return
-                    config = yaml.safe_load(f)
-                else:
-                    import json
+    def _set_enabled_true(self):
+        """Enable scheduler."""
+        self.config_editor.set_enabled(True, self.scheduler)
 
-                    config = json.load(f)
-        else:
-            config = self._get_default_config()
-
-        print("\nCurrent settings:")
-        print(f"  1. Enabled: {config.get('enabled', True)}")
-        print(f"  2. Morning routine: {config.get('morning_routine_time', '09:20:00')}")
-        print(f"  3. Evening routine: {config.get('evening_routine_time', '15:50:00')}")
-        print(f"  4. Max retries: {config.get('max_retries', 3)}")
-        print(f"  5. Dry run mode: {config.get('dry_run', False)}")
-        print("  0. Save and exit")
-        print("  q. Cancel")
-
-        while True:
-            choice = input("\nEdit setting (1-5, 0 to save, q to cancel): ").strip()
-
-            if choice == "q":
-                print("Cancelled")
-                return
-            elif choice == "0":
-                # Save config
-                self._save_config(config)
-                print("✅ Configuration saved!")
-
-                # Reload scheduler if running
-                if self.scheduler:
-                    print("🔄 Reloading scheduler...")
-                    # Reuse existing trading_cycle to avoid creating duplicate Alpaca clients
-                    existing_cycle = self.scheduler.trading_cycle
-                    self.scheduler = DailyScheduler(self.config_file, trading_cycle=existing_cycle)
-                    print("✅ Scheduler reloaded")
-                break
-            elif choice == "1":
-                value = input("Enable scheduler? (yes/no): ").strip().lower()
-                config["enabled"] = value in ["yes", "y", "true"]
-            elif choice == "2":
-                value = input("Morning routine time (HH:MM:SS): ").strip()
-                try:
-                    dt_time.fromisoformat(value)  # Validate
-                    config["morning_routine_time"] = value
-                except ValueError:
-                    print("❌ Invalid time format. Use HH:MM:SS")
-            elif choice == "3":
-                value = input("Evening routine time (HH:MM:SS): ").strip()
-                try:
-                    dt_time.fromisoformat(value)  # Validate
-                    config["evening_routine_time"] = value
-                except ValueError:
-                    print("❌ Invalid time format. Use HH:MM:SS")
-            elif choice == "4":
-                value = input("Max retries (1-10): ").strip()
-                try:
-                    retries = int(value)
-                    if 1 <= retries <= 10:
-                        config["max_retries"] = retries
-                    else:
-                        print("❌ Value must be between 1 and 10")
-                except ValueError:
-                    print("❌ Invalid number")
-            elif choice == "5":
-                value = input("Enable dry run mode? (yes/no): ").strip().lower()
-                config["dry_run"] = value in ["yes", "y", "true"]
-            else:
-                print("Invalid choice")
-
-    def _save_config(self, config: dict):
-        """Save configuration to file."""
-        os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
-
-        with open(self.config_file, "w") as f:
-            if self.config_file.endswith(".yaml") or self.config_file.endswith(".yml"):
-                if yaml is None:
-                    raise ImportError("PyYAML not installed")
-                yaml.safe_dump(config, f, default_flow_style=False, sort_keys=False)
-            else:
-                import json
-
-                json.dump(config, f, indent=2)
-
-    def _get_default_config(self) -> dict:
-        """Get default scheduler configuration."""
-        return {
-            "enabled": True,
-            "market_timezone": "America/New_York",
-            "morning_routine_time": "09:20:00",
-            "evening_routine_time": "15:50:00",
-            "max_retries": 3,
-            "retry_delay_seconds": 60,
-            "timeout_seconds": 300,
-            "enable_notifications": False,
-            "dry_run": False,
-        }
-
-    def _set_enabled(self, enabled: bool):
-        """Enable or disable scheduler."""
-        if os.path.exists(self.config_file):
-            with open(self.config_file, "r") as f:
-                if self.config_file.endswith(".yaml") or self.config_file.endswith(".yml"):
-                    import yaml
-
-                    config = yaml.safe_load(f)
-                else:
-                    import json
-
-                    config = json.load(f)
-
-            config["enabled"] = enabled
-            self._save_config(config)
-
-            status = "enabled" if enabled else "disabled"
-            emoji = "✅" if enabled else "❌"
-            print(f"\n{emoji} Scheduler {status}")
-
-            if self.scheduler:
-                self.scheduler.config["enabled"] = enabled
-        else:
-            print(f"❌ Config file not found: {self.config_file}")
+    def _set_enabled_false(self):
+        """Disable scheduler."""
+        self.config_editor.set_enabled(False, self.scheduler)
 
     async def _test_routine(self, routine_type: str = ""):
-        """Test a scheduler routine (morning or evening)."""
-        # Validate argument
+        """Test a scheduler routine."""
         if routine_type not in ["morning", "evening"]:
             print("Usage: test [morning|evening]")
             return
 
-        print(f"\n{_get_emoji('test', '🧪')} Testing {routine_type} routine...")
+        print(f"\n{get_emoji('test', '🧪')} Testing {routine_type} routine...")
 
         if not self.scheduler:
-            print(f"{_get_emoji('cross_red', '❌')} Scheduler not initialized")
+            print(f"{get_emoji('cross_red', '❌')} Scheduler not initialized")
             return
 
         try:
-            # Call the correct method based on routine type
             if routine_type == "morning":
                 report = self.scheduler.trading_cycle.morning_routine()
             else:
                 report = self.scheduler.trading_cycle.evening_routine()
 
-            print(f"\n✅ {routine_type.capitalize()} routine completed")
+            print(
+                f"\n{get_emoji('check_green', '✅')} {routine_type.capitalize()} routine completed"
+            )
             print("\nReport preview:")
             print("-" * 70)
-            # Show first 500 chars of report
             preview = report[:500] + "..." if len(report) > 500 else report
             print(preview)
             print("-" * 70)
             print("\nFull report saved to: reports/daily/")
         except Exception as e:
-            print(f"❌ Test failed: {e}")
+            print(f"{get_emoji('cross_red', '❌')} Test failed: {e}")
             logger.error(f"Routine test error: {e}", exc_info=True)
 
     def _show_history(self):
         """Show execution history."""
-        if not self.scheduler:
-            print("❌ Scheduler not initialized")
-            return
-
-        print("\n📜 Execution History")
-        print("=" * 70)
-
-        history = self.scheduler.get_execution_history(days=7)
-
-        if not history:
-            print("No execution history found")
-            return
-
-        print("\nShowing last 20 executions (7 days):\n")
-
-        for entry in history[:20]:
-            status_emoji = "✅" if entry.status == "completed" else "❌"
-            time_str = (
-                entry.actual_end_time.strftime("%Y-%m-%d %H:%M")
-                if entry.actual_end_time
-                else "In Progress"
-            )
-
-            print(f"{status_emoji} {entry.task_name:20s} {entry.status:12s} {time_str}")
-            if entry.error_message:
-                print(f"   ⚠️  {entry.error_message[:60]}...")
+        self.monitor.show_history()
 
     def _show_next_run(self):
-        """Calculate and show next scheduled run."""
-        if not self.scheduler:
-            print("❌ Scheduler not initialized")
-            return
-
-        print("\n🔮 Next Scheduled Run")
-        print("=" * 70)
-
-        try:
-            import pytz
-
-            et = pytz.timezone("US/Eastern")
-            now = get_datetime_now(et)
-
-            morning_time = dt_time.fromisoformat(self.scheduler.config["morning_routine_time"])
-            evening_time = dt_time.fromisoformat(self.scheduler.config["evening_routine_time"])
-
-            morning_today = now.replace(
-                hour=morning_time.hour, minute=morning_time.minute, second=0, microsecond=0
-            )
-            evening_today = now.replace(
-                hour=evening_time.hour, minute=evening_time.minute, second=0, microsecond=0
-            )
-
-            if now.time() < morning_time:
-                next_run = morning_today
-                next_task = "Morning Routine"
-            elif now.time() < evening_time:
-                next_run = evening_today
-                next_task = "Evening Routine"
-            else:
-                from datetime import timedelta
-
-                next_run = morning_today + timedelta(days=1)
-                next_task = "Morning Routine (tomorrow)"
-
-            time_until = next_run - now
-            hours = int(time_until.total_seconds() // 3600)
-            minutes = int((time_until.total_seconds() % 3600) // 60)
-
-            print(f"\n⏰ {next_task}")
-            print(f"   Time: {next_run.strftime('%H:%M %p')} ET")
-            print(f"   Countdown: {hours}h {minutes}m")
-            print(f"   Date: {next_run.strftime('%Y-%m-%d')}")
-
-        except Exception as e:
-            print(f"❌ Error calculating next run: {e}")
+        """Show next scheduled run."""
+        self.monitor.show_next_run()
 
     async def _run_setup_wizard(self):
-        """
-        Issue #338: First-time setup wizard for layman users.
-
-        Guides through:
-        1. Welcome and explanation
-        2. Schedule frequency (twice daily, morning only, evening only)
-        3. Time configuration
-        4. Save and optionally start
-        """
-        print("\n" + "=" * 70)
-        print("   🧙 Scheduler Setup Wizard")
-        print("=" * 70)
-
-        print("\n📖 What does the scheduler do?")
-        print("   The scheduler automatically runs trading routines at set times:")
-        print("   • Morning routine: Pre-market check, prepare for trading day")
-        print("   • Evening routine: End-of-day review, adjust stops")
-
-        print("\n" + "-" * 70)
-
-        # Step 1: Schedule frequency
-        print("\n1️⃣  How often should the scheduler run?")
-        print("   1. Twice daily (morning + evening) - RECOMMENDED")
-        print("   2. Morning only (pre-market)")
-        print("   3. Evening only (end-of-day)")
-        print("   4. Cancel setup")
-
-        choice = input("\nChoice [1-4]: ").strip()
-
-        if choice == "4":
-            print("\n❌ Setup cancelled")
-            return
-
-        enable_morning = choice in ["1", "2"]
-        enable_evening = choice in ["1", "3"]
-
-        # Step 2: Time configuration
-        config = self._get_default_config()
-
-        if enable_morning:
-            print("\n2️⃣  Morning routine time (default: 9:20 AM ET, 10 min before market)")
-            print("   Press Enter for default, or enter time like '9:00' or '09:30'")
-            time_input = input("   Morning time: ").strip()
-            if time_input:
-                try:
-                    # Parse simple time formats
-                    if ":" in time_input:
-                        parts = time_input.replace("am", "").replace("pm", "").strip().split(":")
-                        hour = int(parts[0])
-                        minute = int(parts[1]) if len(parts) > 1 else 0
-                        config["morning_routine_time"] = f"{hour:02d}:{minute:02d}:00"
-                except ValueError:
-                    print("   ⚠️  Invalid format, using default 9:20 AM")
-
-        if enable_evening:
-            print("\n3️⃣  Evening routine time (default: 3:50 PM ET, 10 min before close)")
-            print("   Press Enter for default, or enter time like '15:30' or '3:45'")
-            time_input = input("   Evening time: ").strip()
-            if time_input:
-                try:
-                    if ":" in time_input:
-                        parts = time_input.replace("pm", "").strip().split(":")
-                        hour = int(parts[0])
-                        if hour < 12:
-                            hour += 12  # Assume PM for evening
-                        minute = int(parts[1]) if len(parts) > 1 else 0
-                        config["evening_routine_time"] = f"{hour:02d}:{minute:02d}:00"
-                except ValueError:
-                    print("   ⚠️  Invalid format, using default 3:50 PM")
-
-        # Disable routines if not selected
-        if not enable_morning:
-            config["morning_routine_enabled"] = False
-        if not enable_evening:
-            config["evening_routine_enabled"] = False
-
-        config["enabled"] = True
-
-        # Step 3: Summary and save
-        print("\n" + "-" * 70)
-        print("\n📋 Configuration Summary:")
-        print(f"   Morning routine: {'✅ Enabled' if enable_morning else '❌ Disabled'}")
-        if enable_morning:
-            print(f"      Time: {config.get('morning_routine_time', 'N/A')} ET")
-        print(f"   Evening routine: {'✅ Enabled' if enable_evening else '❌ Disabled'}")
-        if enable_evening:
-            print(f"      Time: {config.get('evening_routine_time', 'N/A')} ET")
-
-        confirm = input("\nSave this configuration? [yes/no]: ").strip().lower()
-
-        if confirm in ["yes", "y"]:
-            self._save_config(config)
-            print("\n✅ Configuration saved!")
-
-            # Offer to start
-            start_now = input("\nStart scheduler now? [yes/no]: ").strip().lower()
-            if start_now in ["yes", "y"]:
-                self._start_daemon()
-        else:
-            print("\n❌ Setup cancelled, configuration not saved")
+        """Run first-time setup wizard."""
+        await self.setup_wizard.run()
 
     def _start_daemon(self):
-        """
-        Issue #338: Start the scheduler daemon.
-
-        Starts the daemon process in the background.
-        """
-        print("\n🚀 Starting Scheduler Daemon...")
-
-        # Check if already running
-        if self._is_daemon_running():
-            print("⚠️  Scheduler daemon is already running!")
-            print("   Use 'stop' to stop it first, or 'status' to check")
-            return
-
-        # Start daemon in background
-        import subprocess
-        import sys
-
-        try:
-            # Get the python executable and main.py path
-            python_exe = sys.executable
-            main_py = Path(__file__).parent.parent.parent / "main.py"
-
-            if not main_py.exists():
-                # Try alternative path
-                main_py = Path("main.py")
-
-            # Start in background
-            if os.name == "nt":  # Windows
-                # Use START /B for background
-                subprocess.Popen(
-                    [python_exe, str(main_py), "--daemon"],
-                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
-            else:  # Unix/Linux/Mac
-                subprocess.Popen(
-                    [python_exe, str(main_py), "--daemon"],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    start_new_session=True,
-                )
-
-            # Wait a moment and check if it started
-            import time
-
-            time.sleep(2)
-
-            if self._is_daemon_running():
-                print("✅ Scheduler daemon started successfully!")
-                print("   Use 'status' to see details")
-                print("   Use 'stop' to stop it later")
-            else:
-                print("⚠️  Daemon may have started but couldn't verify")
-                print("   Check logs with 'logs' command")
-
-        except Exception as e:
-            print(f"❌ Failed to start daemon: {e}")
-            print("   Try running manually: python main.py --daemon")
+        """Start scheduler daemon."""
+        self.daemon_manager.start()
 
     def _stop_daemon(self):
-        """
-        Issue #338: Stop the scheduler daemon.
-        """
-        print("\n🛑 Stopping Scheduler Daemon...")
+        """Stop scheduler daemon."""
+        self.daemon_manager.stop()
 
-        if not self._is_daemon_running():
-            print("ℹ️  Scheduler daemon is not running")
-            return
-
-        # Try to stop gracefully
-        pid_file = Path("state/scheduler.pid")
-
-        if pid_file.exists():
-            try:
-                pid = int(pid_file.read_text())
-
-                if os.name == "nt":  # Windows
-                    import signal
-
-                    os.kill(pid, signal.SIGTERM)
-                else:  # Unix
-                    os.kill(pid, 15)  # SIGTERM
-
-                # Wait and verify
-                import time
-
-                time.sleep(2)
-
-                if not self._is_daemon_running():
-                    print("✅ Scheduler daemon stopped successfully!")
-                    # Clean up PID file
-                    pid_file.unlink(missing_ok=True)
-                else:
-                    print("⚠️  Daemon may still be running")
-                    print("   Try: kill -9 " + str(pid))
-
-            except (OSError, ValueError) as e:
-                print(f"⚠️  Could not stop daemon: {e}")
-                print("   You may need to kill the process manually")
-        else:
-            print("⚠️  PID file not found, daemon may not be managed")
-            print("   Check running processes for 'main.py --daemon'")
-
-    def _show_logs(self, lines: int = 50):
-        """
-        Issue #338: Show recent scheduler logs.
-        """
-        print("\n📜 Recent Scheduler Logs")
-        print("=" * 70)
-
-        # Look for log files
-        log_paths = [
-            Path("logs/scheduler.log"),
-            Path("logs/autotrader.log"),
-            Path("state/scheduler_history.json"),
-        ]
-
-        log_file = None
-        for path in log_paths:
-            if path.exists():
-                log_file = path
-                break
-
-        if not log_file:
-            print("ℹ️  No log files found")
-            print("   Logs are created when the scheduler runs")
-            print("   Try 'test morning' or 'start' first")
-            return
-
-        print(f"\nShowing last {lines} lines from: {log_file}\n")
-        print("-" * 70)
-
+    def _show_logs(self, lines: str = "50"):
+        """Show scheduler logs."""
         try:
-            with open(log_file, "r") as f:
-                all_lines = f.readlines()
-                recent = all_lines[-lines:] if len(all_lines) > lines else all_lines
+            num_lines = int(lines)
+        except ValueError:
+            num_lines = 50
+        self.monitor.show_logs(num_lines)
 
-                for line in recent:
-                    # Highlight errors and warnings
-                    if "ERROR" in line or "error" in line.lower():
-                        print(f"❌ {line.rstrip()}")
-                    elif "WARNING" in line or "warn" in line.lower():
-                        print(f"⚠️  {line.rstrip()}")
-                    elif "SUCCESS" in line or "completed" in line.lower():
-                        print(f"✅ {line.rstrip()}")
-                    else:
-                        print(f"   {line.rstrip()}")
-
-        except Exception as e:
-            print(f"❌ Error reading logs: {e}")
-
-        print("-" * 70)
-        print(f"\n💡 Full logs at: {log_file}")
+    def _exit_cli(self):
+        """Exit the scheduler CLI."""
+        print(f"\n{get_emoji('wave', '👋')} Exiting scheduler CLI...")
+        self._running = False
 
 
 async def main():


### PR DESCRIPTION
## Summary
- Extract 5 reusable components from scheduler_cli.py to `src/cli/scheduler/`
- Reduce scheduler_cli.py from 984 to 307 lines (69% reduction)
- Components: message_loader, daemon_manager, config_editor, monitor, setup_wizard

## Test plan
- [ ] Verify `python main.py scheduler status` works
- [ ] Verify `python main.py scheduler config` interactive editing works
- [ ] Verify daemon start/stop on both Windows and Linux
- [ ] Run unit tests: `python -m unittest discover tests`

Closes #440