### PR TITLE
refactor(#442): Extract state manager and reporter from trading orchestrator

### DIFF
--- a/src/autogen_agents/trading_orchestrator.py
+++ b/src/autogen_agents/trading_orchestrator.py
@@ -6,16 +6,16 @@ Coordinates all trading agents (Scanner, Voter, Risk, Executor) and manages
 the end-to-end trading workflow with human-in-loop integration.
 
 Issue #389: TradingOrchestrator - Multi-Agent Coordination and Workflow
+Refactored: Issue #442 - Extract state management and reporting
 
 Key Features:
 1. Workflow Management - Morning routine, continuous monitoring, evening summary
-2. State Management - Workflow progress tracking, persistence, recovery
+2. State Management - Delegated to WorkflowStateManager
 3. Human-in-Loop Modes - CONFIRM (human approval) vs AUTO (autonomous)
 4. Error Recovery - Retry logic, graceful failure handling
 5. Agent Health Checks - Lifecycle management, health monitoring
 """
 
-import json
 import logging
 import time
 from dataclasses import dataclass, field
@@ -28,6 +28,11 @@ from config_defaults.trading_config import TradingConfig
 
 from src.autogen_agents.agent_bus import AgentMessage, EventType, get_agent_bus
 from src.autogen_agents.agent_factory import AgentType, get_agent_factory
+from src.autogen_agents.workflow_reporter import WorkflowReporter
+from src.autogen_agents.workflow_state_manager import (
+    WorkflowPhase,
+    WorkflowStateManager,
+)
 from src.utils.date_utils import get_datetime_now, now_iso
 
 logger = logging.getLogger(__name__)
@@ -40,83 +45,6 @@ class ExecutionMode(Enum):
     AUTO = "auto"  # Autonomous execution (within risk limits)
     PAPER = "paper"  # Paper trading only, no real execution
     DISABLED = "disabled"  # Trading disabled
-
-
-class WorkflowPhase(Enum):
-    """Phases in the trading workflow."""
-
-    IDLE = "idle"
-    SCANNING = "scanning"
-    ANALYZING = "analyzing"
-    RISK_CHECKING = "risk_checking"
-    AWAITING_APPROVAL = "awaiting_approval"
-    EXECUTING = "executing"
-    MONITORING = "monitoring"
-    REPORTING = "reporting"
-    ERROR = "error"
-
-
-@dataclass
-class WorkflowState:
-    """Tracks current workflow progress for recovery."""
-
-    phase: WorkflowPhase = WorkflowPhase.IDLE
-    started_at: Optional[str] = None
-    last_updated: str = field(default_factory=now_iso)
-
-    # Scan results
-    symbols_scanned: List[str] = field(default_factory=list)
-    opportunities_found: Dict[str, Any] = field(default_factory=dict)
-
-    # Analysis results
-    signals_analyzed: Dict[str, Any] = field(default_factory=dict)
-    risk_validated: Dict[str, Any] = field(default_factory=dict)
-
-    # Pending human approval
-    pending_approvals: Dict[str, Any] = field(default_factory=dict)
-
-    # Execution tracking
-    trades_executed: List[Dict[str, Any]] = field(default_factory=list)
-    trades_failed: List[Dict[str, Any]] = field(default_factory=list)
-
-    # Error tracking
-    errors: List[Dict[str, Any]] = field(default_factory=list)
-    retry_count: int = 0
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary for persistence."""
-        return {
-            "phase": self.phase.value,
-            "started_at": self.started_at,
-            "last_updated": self.last_updated,
-            "symbols_scanned": self.symbols_scanned,
-            "opportunities_found": self.opportunities_found,
-            "signals_analyzed": self.signals_analyzed,
-            "risk_validated": self.risk_validated,
-            "pending_approvals": self.pending_approvals,
-            "trades_executed": self.trades_executed,
-            "trades_failed": self.trades_failed,
-            "errors": self.errors,
-            "retry_count": self.retry_count,
-        }
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "WorkflowState":
-        """Restore from dictionary."""
-        state = cls()
-        state.phase = WorkflowPhase(data.get("phase", "idle"))
-        state.started_at = data.get("started_at")
-        state.last_updated = data.get("last_updated", now_iso())
-        state.symbols_scanned = data.get("symbols_scanned", [])
-        state.opportunities_found = data.get("opportunities_found", {})
-        state.signals_analyzed = data.get("signals_analyzed", {})
-        state.risk_validated = data.get("risk_validated", {})
-        state.pending_approvals = data.get("pending_approvals", {})
-        state.trades_executed = data.get("trades_executed", [])
-        state.trades_failed = data.get("trades_failed", [])
-        state.errors = data.get("errors", [])
-        state.retry_count = data.get("retry_count", 0)
-        return state
 
 
 @dataclass
@@ -141,7 +69,6 @@ class TradingOrchestrator:
 
     MAX_RETRIES = 3
     RETRY_DELAY_SECONDS = 5
-    STATE_FILE = "orchestrator_state.json"
 
     def __init__(
         self,
@@ -163,10 +90,8 @@ class TradingOrchestrator:
         self.initial_capital = initial_capital
         self.execution_mode = execution_mode
 
-        # State management
-        self.state_dir = Path(state_dir or "./state")
-        self.state_dir.mkdir(parents=True, exist_ok=True)
-        self.workflow_state = WorkflowState()
+        # State management (extracted component)
+        self._state_manager = WorkflowStateManager(state_dir=state_dir)
 
         # Get factory and bus singletons
         self._factory = get_agent_factory()
@@ -189,12 +114,26 @@ class TradingOrchestrator:
 
         # Auto-recover if enabled
         if auto_recover:
-            self._recover_state()
+            self._state_manager.recover_state()
 
         logger.info("TradingOrchestrator initialized:")
         logger.info(f"  Execution Mode: {execution_mode.value}")
         logger.info(f"  Initial Capital: ${initial_capital:,.2f}")
-        logger.info(f"  State Directory: {self.state_dir}")
+        logger.info(f"  State Directory: {self._state_manager.state_dir}")
+
+    # =========================================================================
+    # Properties for backward compatibility
+    # =========================================================================
+
+    @property
+    def workflow_state(self):
+        """Access workflow state (backward compatibility)."""
+        return self._state_manager.workflow_state
+
+    @property
+    def state_dir(self) -> Path:
+        """Access state directory (backward compatibility)."""
+        return self._state_manager.state_dir
 
     # =========================================================================
     # Agent Management
@@ -299,108 +238,60 @@ class TradingOrchestrator:
         if not self.trading_enabled:
             return {"error": "Trading is disabled", "timestamp": now_iso()}
 
-        self._update_state(WorkflowPhase.SCANNING, started_at=now_iso())
+        self._state_manager.update_state(WorkflowPhase.SCANNING, started_at=now_iso())
 
         try:
             # Step 1: Scan for opportunities
             print("🌅 Starting Morning Routine...")
             print("   📊 Phase 1: Scanning markets...")
 
-            # ScannerAgent.scan_market() returns List[ScanResult]
             scan_result_list = self._execute_with_retry(
                 lambda: self.scanner.scan_market(symbols),
                 "market_scan",
             )
 
-            # Convert to dict for workflow state
             scan_results = {r.symbol: r.to_dict() for r in scan_result_list}
             self.workflow_state.symbols_scanned = [r.symbol for r in scan_result_list]
             self.workflow_state.opportunities_found = scan_results
-            self._save_state()
+            self._state_manager.save_state()
 
-            # Step 2: Analyze signals with VoterAgent
-            # ScannerAgent already provides MACD+RSI analysis in ScanResult
-            # VoterAgent can provide additional evaluation if needed
-            self._update_state(WorkflowPhase.ANALYZING)
+            # Step 2: Analyze signals
+            self._state_manager.update_state(WorkflowPhase.ANALYZING)
             print("   🎯 Phase 2: Analyzing trading signals...")
 
-            analysis_results = {}
-            for scan_result in scan_result_list:
-                symbol = scan_result.symbol
-                if scan_result.error:
-                    analysis_results[symbol] = {"error": scan_result.error}
-                    continue
-
-                # Use ScanResult data directly - it already has MACD+RSI analysis
-                analysis_results[symbol] = {
-                    "symbol": symbol,
-                    "decision": (
-                        f"ENTER_{scan_result.action}" if scan_result.action != "HOLD" else "HOLD"
-                    ),
-                    "action": scan_result.action,
-                    "confidence": scan_result.confidence,
-                    "signal_type": scan_result.signal_type,
-                    "current_price": scan_result.current_price,
-                    "macd_signal": scan_result.macd_signal,
-                    "macd_histogram": scan_result.macd_histogram,
-                    "rsi_value": scan_result.rsi_value,
-                    "rsi_signal": scan_result.rsi_signal,
-                    "ranking_score": scan_result.ranking_score,
-                }
-
+            analysis_results = self._analyze_scan_results(scan_result_list)
             self.workflow_state.signals_analyzed = analysis_results
-            self._save_state()
+            self._state_manager.save_state()
 
             # Step 3: Risk validation
-            self._update_state(WorkflowPhase.RISK_CHECKING)
+            self._state_manager.update_state(WorkflowPhase.RISK_CHECKING)
             print("   🛡️  Phase 3: Validating risk parameters...")
 
             account_status = self.executor.get_account_status()
             current_positions = self.executor.get_positions().get("active_positions", [])
-
-            validated_trades = {}
-            for symbol, analysis in analysis_results.items():
-                if analysis.get("decision", "").startswith("ENTER"):
-                    try:
-                        trade_proposal = {
-                            "symbol": symbol,
-                            "entry_price": analysis.get("current_price", 0),
-                            "stop_price": analysis.get("stop_loss", 0),
-                            "target_price": analysis.get("take_profit", 0),
-                            "action": "BUY",
-                            "confidence": analysis.get("confidence", 0.5),
-                        }
-
-                        risk_result = self.risk.validate_trade(
-                            trade_proposal,
-                            account_status.get("total_value", self.initial_capital),
-                            current_positions,
-                        )
-
-                        validated_trades[symbol] = {
-                            "analysis": analysis,
-                            "risk_validation": risk_result,
-                            "approved": risk_result.get("approved", False),
-                        }
-                    except Exception as e:
-                        validated_trades[symbol] = {"error": str(e)}
-                        self._record_error("risk_validation", symbol, str(e))
+            validated_trades = self._validate_trades(
+                analysis_results, account_status, current_positions
+            )
 
             self.workflow_state.risk_validated = validated_trades
-            self._save_state()
+            self._state_manager.save_state()
 
             # Step 4: Handle execution based on mode
             execution_results = self._handle_execution(validated_trades, account_status)
 
             # Step 5: Generate report
-            self._update_state(WorkflowPhase.REPORTING)
+            self._state_manager.update_state(WorkflowPhase.REPORTING)
             print("   📝 Phase 5: Generating report...")
 
-            report = self._generate_workflow_report(
-                scan_results, analysis_results, validated_trades, execution_results
+            report = WorkflowReporter.generate_workflow_report(
+                self.execution_mode.value,
+                scan_results,
+                analysis_results,
+                validated_trades,
+                execution_results,
             )
 
-            self._update_state(WorkflowPhase.IDLE)
+            self._state_manager.update_state(WorkflowPhase.IDLE)
             print("✅ Morning Routine Complete!")
 
             return {
@@ -414,10 +305,73 @@ class TradingOrchestrator:
             }
 
         except Exception as e:
-            self._update_state(WorkflowPhase.ERROR)
-            self._record_error("morning_routine", "workflow", str(e))
+            self._state_manager.update_state(WorkflowPhase.ERROR)
+            self._state_manager.record_error("morning_routine", "workflow", str(e))
             logger.error(f"Morning routine failed: {e}")
             return {"error": str(e), "timestamp": now_iso()}
+
+    def _analyze_scan_results(self, scan_result_list: list) -> Dict[str, Any]:
+        """Analyze scan results and generate analysis dict."""
+        analysis_results = {}
+        for scan_result in scan_result_list:
+            symbol = scan_result.symbol
+            if scan_result.error:
+                analysis_results[symbol] = {"error": scan_result.error}
+                continue
+
+            analysis_results[symbol] = {
+                "symbol": symbol,
+                "decision": (
+                    f"ENTER_{scan_result.action}" if scan_result.action != "HOLD" else "HOLD"
+                ),
+                "action": scan_result.action,
+                "confidence": scan_result.confidence,
+                "signal_type": scan_result.signal_type,
+                "current_price": scan_result.current_price,
+                "macd_signal": scan_result.macd_signal,
+                "macd_histogram": scan_result.macd_histogram,
+                "rsi_value": scan_result.rsi_value,
+                "rsi_signal": scan_result.rsi_signal,
+                "ranking_score": scan_result.ranking_score,
+            }
+        return analysis_results
+
+    def _validate_trades(
+        self,
+        analysis_results: Dict[str, Any],
+        account_status: Dict[str, Any],
+        current_positions: list,
+    ) -> Dict[str, Any]:
+        """Validate trades through risk agent."""
+        validated_trades = {}
+        for symbol, analysis in analysis_results.items():
+            if analysis.get("decision", "").startswith("ENTER"):
+                try:
+                    trade_proposal = {
+                        "symbol": symbol,
+                        "entry_price": analysis.get("current_price", 0),
+                        "stop_price": analysis.get("stop_loss", 0),
+                        "target_price": analysis.get("take_profit", 0),
+                        "action": "BUY",
+                        "confidence": analysis.get("confidence", 0.5),
+                    }
+
+                    risk_result = self.risk.validate_trade(
+                        trade_proposal,
+                        account_status.get("total_value", self.initial_capital),
+                        current_positions,
+                    )
+
+                    validated_trades[symbol] = {
+                        "analysis": analysis,
+                        "risk_validation": risk_result,
+                        "approved": risk_result.get("approved", False),
+                    }
+                except Exception as e:
+                    validated_trades[symbol] = {"error": str(e)}
+                    self._state_manager.record_error("risk_validation", symbol, str(e))
+
+        return validated_trades
 
     def run_continuous_monitoring(
         self, interval_minutes: int = 15, duration_hours: Optional[float] = None
@@ -430,7 +384,7 @@ class TradingOrchestrator:
             duration_hours: How long to run (None = until shutdown)
         """
         print(f"📈 Starting Continuous Monitoring (every {interval_minutes} min)...")
-        self._update_state(WorkflowPhase.MONITORING)
+        self._state_manager.update_state(WorkflowPhase.MONITORING)
 
         start_time = get_datetime_now()
         end_time = start_time + timedelta(hours=duration_hours) if duration_hours else None
@@ -443,7 +397,6 @@ class TradingOrchestrator:
             try:
                 result = self.monitor_positions()
 
-                # Check for exit signals
                 if result.get("exit_recommendations"):
                     for symbol, rec in result["exit_recommendations"].items():
                         if rec.get("should_exit"):
@@ -451,7 +404,6 @@ class TradingOrchestrator:
                                 f"Exit signal for {symbol}: {rec.get('reason', 'Unknown')}"
                             )
 
-                # Check for stop/target triggers
                 for exit in result.get("automatic_exits", []):
                     self._notify(
                         f"Position closed: {exit['symbol']} - {exit.get('reason', 'Triggered')}"
@@ -459,21 +411,15 @@ class TradingOrchestrator:
 
             except Exception as e:
                 logger.error(f"Monitoring error: {e}")
-                self._record_error("monitoring", "continuous", str(e))
+                self._state_manager.record_error("monitoring", "continuous", str(e))
 
-            # Wait for next interval
             time.sleep(interval_minutes * 60)
 
-        self._update_state(WorkflowPhase.IDLE)
+        self._state_manager.update_state(WorkflowPhase.IDLE)
         print("✅ Continuous Monitoring Stopped")
 
     def monitor_positions(self) -> Dict[str, Any]:
-        """
-        Monitor existing positions for exit signals.
-
-        Returns:
-            Position monitoring results with exit recommendations
-        """
+        """Monitor existing positions for exit signals."""
         positions_info = self.executor.get_positions()
         active_positions = positions_info.get("active_positions", [])
 
@@ -484,11 +430,10 @@ class TradingOrchestrator:
                 "timestamp": now_iso(),
             }
 
-        # Fetch current prices by scanning position symbols
+        # Fetch current prices
         current_prices = {}
         position_symbols = [p["symbol"] for p in active_positions]
         try:
-            # Use scanner to get current prices
             scan_results = self.scanner.scan_market(position_symbols)
             for result in scan_results:
                 if result.current_price > 0:
@@ -496,7 +441,6 @@ class TradingOrchestrator:
         except Exception as e:
             logger.warning(f"Failed to scan for current prices: {e}")
 
-        # Update positions
         update_result = self.executor.update_positions(current_prices)
 
         # Evaluate exit signals
@@ -504,7 +448,7 @@ class TradingOrchestrator:
         for position in active_positions:
             symbol = position["symbol"]
             if symbol in [e.get("symbol") for e in update_result.get("triggered_exits", [])]:
-                continue  # Already exited
+                continue
 
             current_price = current_prices.get(symbol, position["entry_price"])
             try:
@@ -524,47 +468,27 @@ class TradingOrchestrator:
         }
 
     def run_evening_summary(self) -> Dict[str, Any]:
-        """
-        Generate end-of-day summary report.
-
-        Returns:
-            Summary of day's trading activity
-        """
+        """Generate end-of-day summary report."""
         print("🌙 Generating Evening Summary...")
 
         account_status = self.executor.get_account_status()
         positions = self.executor.get_positions()
 
-        # Calculate day's P&L
-        daily_pnl = account_status.get("realized_pnl", 0)
-        unrealized_pnl = account_status.get("unrealized_pnl", 0)
+        workflow_stats = self._state_manager.get_state_summary()
 
-        # Get workflow statistics
-        workflow_stats = {
-            "symbols_scanned": len(self.workflow_state.symbols_scanned),
-            "trades_executed": len(self.workflow_state.trades_executed),
-            "trades_failed": len(self.workflow_state.trades_failed),
-            "errors": len(self.workflow_state.errors),
-        }
-
-        summary = {
-            "date": get_datetime_now().strftime("%Y-%m-%d"),
-            "account_status": account_status,
-            "positions": positions,
-            "daily_pnl": daily_pnl,
-            "unrealized_pnl": unrealized_pnl,
-            "total_pnl": daily_pnl + unrealized_pnl,
-            "workflow_stats": workflow_stats,
-            "agent_health": {
-                k: {"is_healthy": v.is_healthy, "error_count": v.error_count}
+        summary = WorkflowReporter.generate_evening_summary(
+            account_status,
+            positions,
+            workflow_stats,
+            {
+                k.value: {"is_healthy": v.is_healthy, "error_count": v.error_count}
                 for k, v in self._agent_health.items()
             },
-            "timestamp": now_iso(),
-        }
+        )
+        summary["timestamp"] = now_iso()
 
         # Reset daily counters
-        self.workflow_state = WorkflowState()
-        self._save_state()
+        self._state_manager.reset_state()
 
         print("✅ Evening Summary Complete")
         return summary
@@ -588,10 +512,8 @@ class TradingOrchestrator:
             return {"status": "no_trades", "message": "No trades approved by risk"}
 
         if self.execution_mode == ExecutionMode.CONFIRM:
-            # Queue for human approval
-            self._update_state(WorkflowPhase.AWAITING_APPROVAL)
-            self.workflow_state.pending_approvals = approved_trades
-            self._save_state()
+            self._state_manager.update_state(WorkflowPhase.AWAITING_APPROVAL)
+            self._state_manager.set_pending_approvals(approved_trades)
 
             print("   ⏳ Phase 4: Awaiting human approval...")
             return {
@@ -601,8 +523,7 @@ class TradingOrchestrator:
             }
 
         elif self.execution_mode in [ExecutionMode.AUTO, ExecutionMode.PAPER]:
-            # Execute automatically
-            self._update_state(WorkflowPhase.EXECUTING)
+            self._state_manager.update_state(WorkflowPhase.EXECUTING)
             print("   ⚡ Phase 4: Executing approved trades...")
 
             execution_results = {}
@@ -611,58 +532,34 @@ class TradingOrchestrator:
                 execution_results[symbol] = result
 
                 if result.get("success"):
-                    self.workflow_state.trades_executed.append(result)
+                    self._state_manager.add_executed_trade(result)
                 else:
-                    self.workflow_state.trades_failed.append(result)
+                    self._state_manager.add_failed_trade(result)
 
-            self._save_state()
-            return {
-                "status": "executed",
-                "results": execution_results,
-            }
+            return {"status": "executed", "results": execution_results}
 
         return {"status": "unknown", "message": f"Unknown mode: {self.execution_mode}"}
 
     def approve_trade(self, symbol: str) -> Dict[str, Any]:
-        """
-        Approve a pending trade (CONFIRM mode).
-
-        Args:
-            symbol: Symbol to approve
-
-        Returns:
-            Execution result
-        """
-        if symbol not in self.workflow_state.pending_approvals:
+        """Approve a pending trade (CONFIRM mode)."""
+        trade_data = self._state_manager.pop_pending_approval(symbol)
+        if not trade_data:
             return {"error": f"No pending approval for {symbol}"}
 
-        trade_data = self.workflow_state.pending_approvals.pop(symbol)
         result = self._execute_trade(symbol, trade_data)
 
         if result.get("success"):
-            self.workflow_state.trades_executed.append(result)
+            self._state_manager.add_executed_trade(result)
         else:
-            self.workflow_state.trades_failed.append(result)
+            self._state_manager.add_failed_trade(result)
 
-        self._save_state()
         return result
 
     def reject_trade(self, symbol: str, reason: str = "User rejected") -> Dict[str, Any]:
-        """
-        Reject a pending trade (CONFIRM mode).
-
-        Args:
-            symbol: Symbol to reject
-            reason: Reason for rejection
-
-        Returns:
-            Rejection confirmation
-        """
-        if symbol not in self.workflow_state.pending_approvals:
+        """Reject a pending trade (CONFIRM mode)."""
+        trade_data = self._state_manager.pop_pending_approval(symbol)
+        if not trade_data:
             return {"error": f"No pending approval for {symbol}"}
-
-        self.workflow_state.pending_approvals.pop(symbol)
-        self._save_state()
 
         return {
             "symbol": symbol,
@@ -673,7 +570,7 @@ class TradingOrchestrator:
 
     def get_pending_approvals(self) -> Dict[str, Any]:
         """Get all trades pending human approval."""
-        return self.workflow_state.pending_approvals.copy()
+        return self._state_manager.get_pending_approvals()
 
     def _execute_trade(self, symbol: str, trade_data: Dict[str, Any]) -> Dict[str, Any]:
         """Execute a single trade."""
@@ -708,47 +605,12 @@ class TradingOrchestrator:
             }
 
     # =========================================================================
-    # State Management
+    # State Management (delegated to WorkflowStateManager)
     # =========================================================================
-
-    def _update_state(self, phase: WorkflowPhase, **kwargs):
-        """Update workflow state."""
-        self.workflow_state.phase = phase
-        self.workflow_state.last_updated = now_iso()
-
-        for key, value in kwargs.items():
-            if hasattr(self.workflow_state, key):
-                setattr(self.workflow_state, key, value)
-
-        self._save_state()
-
-    def _save_state(self):
-        """Persist workflow state to disk."""
-        try:
-            state_path = self.state_dir / self.STATE_FILE
-            with open(state_path, "w") as f:
-                json.dump(self.workflow_state.to_dict(), f, indent=2, default=str)
-        except Exception as e:
-            logger.warning(f"Failed to save state: {e}")
-
-    def _recover_state(self):
-        """Recover workflow state from disk."""
-        try:
-            state_path = self.state_dir / self.STATE_FILE
-            if state_path.exists():
-                with open(state_path, "r") as f:
-                    data = json.load(f)
-                self.workflow_state = WorkflowState.from_dict(data)
-                logger.info(f"Recovered state: phase={self.workflow_state.phase.value}")
-        except Exception as e:
-            logger.warning(f"Failed to recover state: {e}")
-            self.workflow_state = WorkflowState()
 
     def reset_state(self):
         """Reset workflow state."""
-        self.workflow_state = WorkflowState()
-        self._save_state()
-        logger.info("Workflow state reset")
+        self._state_manager.reset_state()
 
     # =========================================================================
     # Error Handling & Retry
@@ -767,30 +629,13 @@ class TradingOrchestrator:
             try:
                 return operation()
             except Exception as e:
-                self.workflow_state.retry_count += 1
+                self._state_manager.increment_retry()
                 logger.warning(f"{operation_name} failed (attempt {attempt + 1}/{retries}): {e}")
 
                 if attempt < retries - 1:
                     time.sleep(self.RETRY_DELAY_SECONDS * (attempt + 1))
                 else:
                     raise
-
-    def _record_error(self, phase: str, symbol: str, error: str):
-        """Record an error in workflow state."""
-        self.workflow_state.errors.append(
-            {
-                "phase": phase,
-                "symbol": symbol,
-                "error": error,
-                "timestamp": now_iso(),
-            }
-        )
-
-    def _count_entry_signals(self, analysis_results: Dict[str, Any]) -> int:
-        """Count entry signals in analysis results."""
-        return sum(
-            1 for r in analysis_results.values() if r.get("decision", "").startswith("ENTER")
-        )
 
     # =========================================================================
     # Event Bus Integration
@@ -832,97 +677,23 @@ class TradingOrchestrator:
             print(f"🔔 {message}")
 
     # =========================================================================
-    # Reporting
+    # Reporting (delegated to WorkflowReporter)
     # =========================================================================
-
-    def _generate_workflow_report(
-        self,
-        scan_results: Dict,
-        analysis_results: Dict,
-        validated_trades: Dict,
-        execution_results: Dict,
-    ) -> str:
-        """Generate comprehensive workflow report."""
-        lines = [
-            "=" * 60,
-            "🤖 TRADING WORKFLOW REPORT",
-            "=" * 60,
-            f"Generated: {get_datetime_now().strftime('%Y-%m-%d %H:%M:%S')}",
-            f"Mode: {self.execution_mode.value.upper()}",
-            "",
-            "📊 SCAN RESULTS:",
-            f"  Symbols Scanned: {len(scan_results)}",
-            f"  Opportunities Found: {sum(1 for r in scan_results.values() if 'error' not in r)}",
-            "",
-            "🎯 ANALYSIS RESULTS:",
-            f"  Signals Analyzed: {len(analysis_results)}",
-            f"  Entry Signals: {self._count_entry_signals(analysis_results)}",
-            "",
-            "🛡️ RISK VALIDATION:",
-            f"  Trades Validated: {len(validated_trades)}",
-            f"  Approved: {sum(1 for r in validated_trades.values() if r.get('approved'))}",
-            "",
-        ]
-
-        # Execution status
-        if execution_results.get("status") == "awaiting_approval":
-            lines.extend(
-                [
-                    "⏳ PENDING APPROVAL:",
-                    f"  Trades Pending: {len(execution_results.get('pending_trades', []))}",
-                ]
-            )
-        elif execution_results.get("status") == "executed":
-            results = execution_results.get("results", {})
-            success = sum(1 for r in results.values() if r.get("success"))
-            lines.extend(
-                [
-                    "⚡ EXECUTION RESULTS:",
-                    f"  Executed: {success}/{len(results)}",
-                ]
-            )
-
-        lines.extend(["", "=" * 60])
-        return "\n".join(lines)
 
     def generate_status_report(self) -> str:
         """Generate current status report."""
         account = self.executor.get_account_status()
         positions = self.executor.get_positions()
 
-        lines = [
-            "=" * 60,
-            "🤖 TRADING ORCHESTRATOR STATUS",
-            "=" * 60,
-            f"Time: {get_datetime_now().strftime('%Y-%m-%d %H:%M:%S')}",
-            f"Phase: {self.workflow_state.phase.value}",
-            f"Mode: {self.execution_mode.value}",
-            f"Trading Enabled: {'Yes' if self.trading_enabled else 'No'}",
-            "",
-            "💰 ACCOUNT:",
-            f"  Total Value: ${account.get('total_value', 0):,.2f}",
-            f"  Available: ${account.get('available_cash', 0):,.2f}",
-            f"  P&L: ${account.get('total_return_pct', 0) * 100:.2f}%",
-            "",
-            f"📊 POSITIONS: {positions.get('total_positions', 0)} active",
-            "",
-            "🔧 AGENT HEALTH:",
-        ]
-
-        for agent_type, health in self._agent_health.items():
-            status = "✅" if health.is_healthy else "❌"
-            lines.append(f"  {agent_type.value}: {status}")
-
-        if self.workflow_state.pending_approvals:
-            lines.extend(
-                [
-                    "",
-                    f"⏳ PENDING APPROVALS: {len(self.workflow_state.pending_approvals)}",
-                ]
-            )
-
-        lines.append("=" * 60)
-        return "\n".join(lines)
+        return WorkflowReporter.generate_status_report(
+            self.execution_mode.value,
+            self.trading_enabled,
+            self.workflow_state.phase.value,
+            account,
+            positions,
+            self._agent_health,
+            self._state_manager.get_pending_approvals(),
+        )
 
     # =========================================================================
     # Lifecycle
@@ -934,10 +705,8 @@ class TradingOrchestrator:
         self._shutdown_requested = True
         self.trading_enabled = False
 
-        # Save final state
-        self._save_state()
+        self._state_manager.save_state()
 
-        # Unsubscribe from events
         try:
             self._bus.unsubscribe("orchestrator", EventType.TRADE_EXECUTED)
             self._bus.unsubscribe("orchestrator", EventType.RISK_VALIDATED)

--- a/src/autogen_agents/trading_orchestrator.py
+++ b/src/autogen_agents/trading_orchestrator.py
@@ -29,10 +29,7 @@ from config_defaults.trading_config import TradingConfig
 from src.autogen_agents.agent_bus import AgentMessage, EventType, get_agent_bus
 from src.autogen_agents.agent_factory import AgentType, get_agent_factory
 from src.autogen_agents.workflow_reporter import WorkflowReporter
-from src.autogen_agents.workflow_state_manager import (
-    WorkflowPhase,
-    WorkflowStateManager,
-)
+from src.autogen_agents.workflow_state_manager import WorkflowPhase, WorkflowStateManager
 from src.utils.date_utils import get_datetime_now, now_iso
 
 logger = logging.getLogger(__name__)

--- a/src/autogen_agents/workflow_reporter.py
+++ b/src/autogen_agents/workflow_reporter.py
@@ -1,0 +1,192 @@
+"""
+Workflow Reporter - report generation for trading workflows.
+
+Generates comprehensive workflow and status reports.
+Extracted from trading_orchestrator.py (Issue #442).
+"""
+
+from typing import Any, Dict
+
+from src.utils.date_utils import get_datetime_now
+
+
+class WorkflowReporter:
+    """
+    Generate reports for trading workflow status.
+
+    Handles:
+    - Workflow summary reports
+    - Status reports
+    - Position reports
+    """
+
+    @staticmethod
+    def count_entry_signals(analysis_results: Dict[str, Any]) -> int:
+        """Count entry signals in analysis results."""
+        return sum(
+            1 for r in analysis_results.values() if r.get("decision", "").startswith("ENTER")
+        )
+
+    @classmethod
+    def generate_workflow_report(
+        cls,
+        execution_mode: str,
+        scan_results: Dict[str, Any],
+        analysis_results: Dict[str, Any],
+        validated_trades: Dict[str, Any],
+        execution_results: Dict[str, Any],
+    ) -> str:
+        """
+        Generate comprehensive workflow report.
+
+        Args:
+            execution_mode: Current execution mode (confirm/auto/paper/disabled)
+            scan_results: Results from market scanning
+            analysis_results: Results from signal analysis
+            validated_trades: Risk-validated trades
+            execution_results: Results from trade execution
+
+        Returns:
+            Formatted report string
+        """
+        lines = [
+            "=" * 60,
+            "🤖 TRADING WORKFLOW REPORT",
+            "=" * 60,
+            f"Generated: {get_datetime_now().strftime('%Y-%m-%d %H:%M:%S')}",
+            f"Mode: {execution_mode.upper()}",
+            "",
+            "📊 SCAN RESULTS:",
+            f"  Symbols Scanned: {len(scan_results)}",
+            f"  Opportunities Found: {sum(1 for r in scan_results.values() if 'error' not in r)}",
+            "",
+            "🎯 ANALYSIS RESULTS:",
+            f"  Signals Analyzed: {len(analysis_results)}",
+            f"  Entry Signals: {cls.count_entry_signals(analysis_results)}",
+            "",
+            "🛡️ RISK VALIDATION:",
+            f"  Trades Validated: {len(validated_trades)}",
+            f"  Approved: {sum(1 for r in validated_trades.values() if r.get('approved'))}",
+            "",
+        ]
+
+        # Execution status
+        if execution_results.get("status") == "awaiting_approval":
+            lines.extend(
+                [
+                    "⏳ PENDING APPROVAL:",
+                    f"  Trades Pending: {len(execution_results.get('pending_trades', []))}",
+                ]
+            )
+        elif execution_results.get("status") == "executed":
+            results = execution_results.get("results", {})
+            success = sum(1 for r in results.values() if r.get("success"))
+            lines.extend(
+                [
+                    "⚡ EXECUTION RESULTS:",
+                    f"  Executed: {success}/{len(results)}",
+                ]
+            )
+
+        lines.extend(["", "=" * 60])
+        return "\n".join(lines)
+
+    @classmethod
+    def generate_status_report(
+        cls,
+        execution_mode: str,
+        trading_enabled: bool,
+        workflow_phase: str,
+        account_status: Dict[str, Any],
+        positions: Dict[str, Any],
+        agent_health: Dict[str, Any],
+        pending_approvals: Dict[str, Any],
+    ) -> str:
+        """
+        Generate current status report.
+
+        Args:
+            execution_mode: Current execution mode
+            trading_enabled: Whether trading is enabled
+            workflow_phase: Current workflow phase
+            account_status: Account status dict
+            positions: Positions info dict
+            agent_health: Agent health status dict
+            pending_approvals: Pending trade approvals
+
+        Returns:
+            Formatted status report string
+        """
+        lines = [
+            "=" * 60,
+            "🤖 TRADING ORCHESTRATOR STATUS",
+            "=" * 60,
+            f"Time: {get_datetime_now().strftime('%Y-%m-%d %H:%M:%S')}",
+            f"Phase: {workflow_phase}",
+            f"Mode: {execution_mode}",
+            f"Trading Enabled: {'Yes' if trading_enabled else 'No'}",
+            "",
+            "💰 ACCOUNT:",
+            f"  Total Value: ${account_status.get('total_value', 0):,.2f}",
+            f"  Available: ${account_status.get('available_cash', 0):,.2f}",
+            f"  P&L: ${account_status.get('total_return_pct', 0) * 100:.2f}%",
+            "",
+            f"📊 POSITIONS: {positions.get('total_positions', 0)} active",
+            "",
+            "🔧 AGENT HEALTH:",
+        ]
+
+        for agent_type, health in agent_health.items():
+            status = "✅" if health.is_healthy else "❌"
+            lines.append(f"  {agent_type}: {status}")
+
+        if pending_approvals:
+            lines.extend(
+                [
+                    "",
+                    f"⏳ PENDING APPROVALS: {len(pending_approvals)}",
+                ]
+            )
+
+        lines.append("=" * 60)
+        return "\n".join(lines)
+
+    @classmethod
+    def generate_evening_summary(
+        cls,
+        account_status: Dict[str, Any],
+        positions: Dict[str, Any],
+        workflow_stats: Dict[str, Any],
+        agent_health: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Generate end-of-day summary.
+
+        Args:
+            account_status: Account status dict
+            positions: Positions info
+            workflow_stats: Workflow statistics
+            agent_health: Agent health status
+
+        Returns:
+            Summary dictionary
+        """
+        daily_pnl = account_status.get("realized_pnl", 0)
+        unrealized_pnl = account_status.get("unrealized_pnl", 0)
+
+        return {
+            "date": get_datetime_now().strftime("%Y-%m-%d"),
+            "account_status": account_status,
+            "positions": positions,
+            "daily_pnl": daily_pnl,
+            "unrealized_pnl": unrealized_pnl,
+            "total_pnl": daily_pnl + unrealized_pnl,
+            "workflow_stats": workflow_stats,
+            "agent_health": {
+                k: {
+                    "is_healthy": v.get("is_healthy", False),
+                    "error_count": v.get("error_count", 0),
+                }
+                for k, v in agent_health.items()
+            },
+        }

--- a/src/autogen_agents/workflow_state_manager.py
+++ b/src/autogen_agents/workflow_state_manager.py
@@ -1,0 +1,263 @@
+"""
+Workflow State Manager - persistence and recovery for trading workflows.
+
+Handles state persistence, recovery, and management for TradingOrchestrator.
+Extracted from trading_orchestrator.py (Issue #442).
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from src.utils.date_utils import now_iso
+
+logger = logging.getLogger(__name__)
+
+
+class WorkflowPhase(Enum):
+    """Phases in the trading workflow."""
+
+    IDLE = "idle"
+    SCANNING = "scanning"
+    ANALYZING = "analyzing"
+    RISK_CHECKING = "risk_checking"
+    AWAITING_APPROVAL = "awaiting_approval"
+    EXECUTING = "executing"
+    MONITORING = "monitoring"
+    REPORTING = "reporting"
+    ERROR = "error"
+
+
+@dataclass
+class WorkflowState:
+    """Tracks current workflow progress for recovery."""
+
+    phase: WorkflowPhase = WorkflowPhase.IDLE
+    started_at: Optional[str] = None
+    last_updated: str = field(default_factory=now_iso)
+
+    # Scan results
+    symbols_scanned: List[str] = field(default_factory=list)
+    opportunities_found: Dict[str, Any] = field(default_factory=dict)
+
+    # Analysis results
+    signals_analyzed: Dict[str, Any] = field(default_factory=dict)
+    risk_validated: Dict[str, Any] = field(default_factory=dict)
+
+    # Pending human approval
+    pending_approvals: Dict[str, Any] = field(default_factory=dict)
+
+    # Execution tracking
+    trades_executed: List[Dict[str, Any]] = field(default_factory=list)
+    trades_failed: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Error tracking
+    errors: List[Dict[str, Any]] = field(default_factory=list)
+    retry_count: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for persistence."""
+        return {
+            "phase": self.phase.value,
+            "started_at": self.started_at,
+            "last_updated": self.last_updated,
+            "symbols_scanned": self.symbols_scanned,
+            "opportunities_found": self.opportunities_found,
+            "signals_analyzed": self.signals_analyzed,
+            "risk_validated": self.risk_validated,
+            "pending_approvals": self.pending_approvals,
+            "trades_executed": self.trades_executed,
+            "trades_failed": self.trades_failed,
+            "errors": self.errors,
+            "retry_count": self.retry_count,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "WorkflowState":
+        """Restore from dictionary."""
+        state = cls()
+        state.phase = WorkflowPhase(data.get("phase", "idle"))
+        state.started_at = data.get("started_at")
+        state.last_updated = data.get("last_updated", now_iso())
+        state.symbols_scanned = data.get("symbols_scanned", [])
+        state.opportunities_found = data.get("opportunities_found", {})
+        state.signals_analyzed = data.get("signals_analyzed", {})
+        state.risk_validated = data.get("risk_validated", {})
+        state.pending_approvals = data.get("pending_approvals", {})
+        state.trades_executed = data.get("trades_executed", [])
+        state.trades_failed = data.get("trades_failed", [])
+        state.errors = data.get("errors", [])
+        state.retry_count = data.get("retry_count", 0)
+        return state
+
+
+class WorkflowStateManager:
+    """
+    Manages workflow state persistence and recovery.
+
+    Handles:
+    - State updates
+    - Persistence to JSON
+    - Recovery from disk
+    - Error recording
+    """
+
+    DEFAULT_STATE_FILE = "orchestrator_state.json"
+
+    def __init__(self, state_dir: Optional[str] = None, state_file: Optional[str] = None):
+        """
+        Initialize state manager.
+
+        Args:
+            state_dir: Directory for state files (default: ./state)
+            state_file: State file name (default: orchestrator_state.json)
+        """
+        self.state_dir = Path(state_dir or "./state")
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.state_file = state_file or self.DEFAULT_STATE_FILE
+        self.workflow_state = WorkflowState()
+
+    @property
+    def state_path(self) -> Path:
+        """Get full path to state file."""
+        return self.state_dir / self.state_file
+
+    def update_state(self, phase: WorkflowPhase, **kwargs) -> None:
+        """
+        Update workflow state.
+
+        Args:
+            phase: New workflow phase
+            **kwargs: Additional state attributes to update
+        """
+        self.workflow_state.phase = phase
+        self.workflow_state.last_updated = now_iso()
+
+        for key, value in kwargs.items():
+            if hasattr(self.workflow_state, key):
+                setattr(self.workflow_state, key, value)
+
+        self.save_state()
+
+    def save_state(self) -> bool:
+        """
+        Persist workflow state to disk.
+
+        Returns:
+            True if saved successfully
+        """
+        try:
+            with open(self.state_path, "w") as f:
+                json.dump(self.workflow_state.to_dict(), f, indent=2, default=str)
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to save state: {e}")
+            return False
+
+    def recover_state(self) -> bool:
+        """
+        Recover workflow state from disk.
+
+        Returns:
+            True if recovered successfully
+        """
+        try:
+            if self.state_path.exists():
+                with open(self.state_path, "r") as f:
+                    data = json.load(f)
+                self.workflow_state = WorkflowState.from_dict(data)
+                logger.info(f"Recovered state: phase={self.workflow_state.phase.value}")
+                return True
+        except Exception as e:
+            logger.warning(f"Failed to recover state: {e}")
+            self.workflow_state = WorkflowState()
+        return False
+
+    def reset_state(self) -> None:
+        """Reset workflow state to initial state."""
+        self.workflow_state = WorkflowState()
+        self.save_state()
+        logger.info("Workflow state reset")
+
+    def record_error(self, phase: str, symbol: str, error: str) -> None:
+        """
+        Record an error in workflow state.
+
+        Args:
+            phase: Workflow phase when error occurred
+            symbol: Symbol associated with error
+            error: Error message
+        """
+        self.workflow_state.errors.append(
+            {
+                "phase": phase,
+                "symbol": symbol,
+                "error": error,
+                "timestamp": now_iso(),
+            }
+        )
+
+    def increment_retry(self) -> int:
+        """
+        Increment retry count.
+
+        Returns:
+            New retry count
+        """
+        self.workflow_state.retry_count += 1
+        return self.workflow_state.retry_count
+
+    def add_executed_trade(self, trade_result: Dict[str, Any]) -> None:
+        """Add a successfully executed trade to state."""
+        self.workflow_state.trades_executed.append(trade_result)
+        self.save_state()
+
+    def add_failed_trade(self, trade_result: Dict[str, Any]) -> None:
+        """Add a failed trade to state."""
+        self.workflow_state.trades_failed.append(trade_result)
+        self.save_state()
+
+    def set_pending_approvals(self, approvals: Dict[str, Any]) -> None:
+        """Set pending approvals for human review."""
+        self.workflow_state.pending_approvals = approvals
+        self.save_state()
+
+    def pop_pending_approval(self, symbol: str) -> Optional[Dict[str, Any]]:
+        """
+        Remove and return a pending approval.
+
+        Args:
+            symbol: Symbol to approve
+
+        Returns:
+            Trade data or None if not found
+        """
+        trade_data = self.workflow_state.pending_approvals.pop(symbol, None)
+        if trade_data:
+            self.save_state()
+        return trade_data
+
+    def get_pending_approvals(self) -> Dict[str, Any]:
+        """Get all pending approvals."""
+        return self.workflow_state.pending_approvals.copy()
+
+    def get_state_summary(self) -> Dict[str, Any]:
+        """
+        Get summary of current state.
+
+        Returns:
+            Dictionary with key state metrics
+        """
+        return {
+            "phase": self.workflow_state.phase.value,
+            "symbols_scanned": len(self.workflow_state.symbols_scanned),
+            "trades_executed": len(self.workflow_state.trades_executed),
+            "trades_failed": len(self.workflow_state.trades_failed),
+            "pending_approvals": len(self.workflow_state.pending_approvals),
+            "errors": len(self.workflow_state.errors),
+            "retry_count": self.workflow_state.retry_count,
+            "last_updated": self.workflow_state.last_updated,
+        }


### PR DESCRIPTION
## Summary
- Extract WorkflowStateManager to `src/autogen_agents/workflow_state_manager.py` (263 lines)
  - State persistence, recovery, and error recording
  - WorkflowState dataclass and WorkflowPhase enum
- Extract WorkflowReporter to `src/autogen_agents/workflow_reporter.py` (189 lines)
  - Workflow report generation
  - Status report generation
  - Evening summary generation
- Reduce trading_orchestrator.py from 958 to 728 lines (24% reduction)
- Maintain backward compatibility with property accessors

## Test plan
- [ ] Verify morning routine workflow executes correctly
- [ ] Verify state persistence/recovery works
- [ ] Verify status reports generate correctly
- [ ] Run unit tests: `python -m unittest discover tests`

Closes #442