### PR TITLE
refactor: Extract components from trading_cycle.py (#439)

### DIFF
--- a/src/trading/broker_state_cache.py
+++ b/src/trading/broker_state_cache.py
@@ -1,0 +1,278 @@
+"""
+BrokerStateCache - Cached broker state with smart TTL management.
+
+Extracted from trading_cycle.py as part of #439 refactoring.
+Handles broker state caching to reduce API calls (Issue #337).
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
+from src.utils.date_utils import get_datetime_now, now_iso
+
+logger = logging.getLogger(__name__)
+
+
+class BrokerStateCache:
+    """
+    Manages cached broker state with TTL-based invalidation.
+
+    Broker is always source of truth. Cache reduces API calls while
+    maintaining freshness within TTL window.
+    """
+
+    def __init__(
+        self,
+        account_monitor: Any,
+        check_alerts_callback: Optional[Callable[[Dict[str, Any]], List[Any]]] = None,
+        cache_ttl_seconds: int = 60,
+        alert_refresh_interval: int = 300,
+    ):
+        """
+        Initialize BrokerStateCache.
+
+        Args:
+            account_monitor: Alpaca account monitor for API calls
+            check_alerts_callback: Optional callback to check position alerts
+            cache_ttl_seconds: How long to keep cached data (default: 60s)
+            alert_refresh_interval: Time between alert refreshes (default: 300s)
+        """
+        self.account_monitor = account_monitor
+        self.check_alerts_callback = check_alerts_callback
+        self.cache_ttl_seconds = cache_ttl_seconds
+        self.alert_refresh_interval = alert_refresh_interval
+
+        # Cache state
+        self._cache: Optional[Dict[str, Any]] = None
+        self._cache_timestamp: Optional[datetime] = None
+
+        # Alert state (Issue #337 Phase 2)
+        self._cached_alerts: List[Any] = []
+        self._last_alert_check: Optional[datetime] = None
+
+        logger.info(
+            f"BrokerStateCache initialized: TTL={cache_ttl_seconds}s, "
+            f"alert_interval={alert_refresh_interval}s"
+        )
+
+    @property
+    def cached_alerts(self) -> List[Any]:
+        """Get cached alerts."""
+        return self._cached_alerts
+
+    def fetch(self, force_refresh: bool = False) -> Dict[str, Any]:
+        """
+        Get all positions and orders from broker with smart caching.
+        This is the source of truth.
+
+        Issue #337: Added caching to reduce API calls. Cache TTL is configurable.
+
+        Args:
+            force_refresh: If True, bypass cache and fetch fresh data from broker
+
+        Returns:
+            Dict with positions, orders, account info, and timestamp
+        """
+        # Check if cached data is still valid
+        if not force_refresh and self._cache is not None:
+            cache_age = (get_datetime_now() - self._cache_timestamp).total_seconds()
+            if cache_age < self.cache_ttl_seconds:
+                logger.debug(f"Using cached broker state (age: {cache_age:.1f}s)")
+                return self._cache
+
+        logger.debug("Cache miss or force_refresh - fetching from broker")
+
+        try:
+            # Get all positions (one API call)
+            positions = self.account_monitor.get_positions()
+
+            # Get all orders (one API call)
+            # Use 'all' to include pending_new, accepted, and other statuses
+            orders = self.account_monitor.get_orders(status="all")
+
+            # Get account info (one API call)
+            account = self.account_monitor.get_account_status()
+
+            # Organize into clean structure
+            broker_state = {
+                "positions": {},
+                "orders": {},
+                "account": {
+                    "buying_power": float(account.get("buying_power", 0)),
+                    "portfolio_value": float(account.get("portfolio_value", 0)),
+                    "cash": float(account.get("cash", 0)),
+                },
+                "timestamp": now_iso(),
+            }
+
+            # Process positions
+            for pos in positions:
+                symbol = pos["symbol"]
+                broker_state["positions"][symbol] = {
+                    "symbol": symbol,
+                    "quantity": int(pos["qty"]),
+                    "entry_price": float(pos["avg_entry_price"]),
+                    "current_price": float(pos["market_value"]) / abs(int(pos["qty"])),
+                    "unrealized_pl": float(pos["unrealized_pl"]),
+                    "side": pos["side"],  # long/short
+                }
+
+            # Process orders (group by symbol)
+            # Only include active orders (not filled, cancelled, expired, etc.)
+            active_statuses = ["new", "pending_new", "accepted", "partially_filled", "held"]
+
+            for order in orders:
+                # Filter to only active orders
+                order_status = str(order.get("status", "")).lower()
+                if not any(status in order_status for status in active_statuses):
+                    continue  # Skip filled, cancelled, expired orders
+
+                symbol = order["symbol"]
+                if symbol not in broker_state["orders"]:
+                    broker_state["orders"][symbol] = []
+
+                # Convert enums to strings for consistent comparison
+                order_entry = {
+                    "id": order["id"],
+                    "type": str(order["order_type"]),  # Convert enum to string
+                    "side": str(order["side"]),  # Convert enum to string
+                    "quantity": int(order["qty"]),
+                    "limit_price": (
+                        float(order.get("limit_price", 0)) if order.get("limit_price") else None
+                    ),
+                    "stop_price": (
+                        float(order.get("stop_price", 0)) if order.get("stop_price") else None
+                    ),
+                    "status": str(order["status"]),  # Convert enum to string
+                    "time_in_force": str(order["time_in_force"]),  # Convert enum to string
+                }
+                broker_state["orders"][symbol].append(order_entry)
+                logger.debug(f"Order {symbol}: {order_entry}")
+
+                # Process bracket order legs (stop-loss and take-profit)
+                if "legs" in order and order["legs"]:
+                    for leg in order["legs"]:
+                        leg_status = str(leg.get("status", "")).lower()
+                        if not any(status in leg_status for status in active_statuses):
+                            continue  # Skip inactive legs
+
+                        leg_entry = {
+                            "id": leg["id"],
+                            "type": str(leg["order_type"]),
+                            "side": str(leg["side"]),
+                            "quantity": int(leg["qty"]),
+                            "limit_price": (
+                                float(leg.get("limit_price", 0)) if leg.get("limit_price") else None
+                            ),
+                            "stop_price": (
+                                float(leg.get("stop_price", 0)) if leg.get("stop_price") else None
+                            ),
+                            "status": str(leg["status"]),
+                            "time_in_force": str(leg["time_in_force"]),
+                            "parent_order_id": order["id"],  # Track parent relationship
+                        }
+                        broker_state["orders"][symbol].append(leg_entry)
+                        logger.debug(f"  Bracket leg {symbol}: {leg_entry}")
+
+            logger.info(
+                f"Fetched broker state: {len(broker_state['positions'])} positions, "
+                f"{len(broker_state['orders'])} order groups, "
+                f"total {len(orders)} orders"
+            )
+
+            # Issue #337: Cache the broker state
+            self._cache = broker_state
+            self._cache_timestamp = get_datetime_now()
+
+            # Issue #337 Phase 2: Piggyback alert check if enough time has passed
+            self._maybe_refresh_alerts(broker_state)
+
+            return broker_state
+
+        except Exception as e:
+            logger.error(f"Failed to fetch broker state: {e}")
+            raise
+
+    def invalidate(self):
+        """
+        Invalidate the broker state cache.
+
+        Issue #337: Call this after placing/modifying/cancelling orders
+        to ensure the next fetch() gets fresh data.
+        """
+        self._cache = None
+        self._cache_timestamp = None
+        logger.debug("Broker state cache invalidated")
+
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        Get cache statistics for debugging/monitoring.
+
+        Returns:
+            Dict with cache_valid, cache_age_seconds, ttl_seconds
+        """
+        if self._cache is None:
+            return {
+                "cache_valid": False,
+                "cache_age_seconds": None,
+                "ttl_seconds": self.cache_ttl_seconds,
+            }
+
+        cache_age = (get_datetime_now() - self._cache_timestamp).total_seconds()
+        return {
+            "cache_valid": cache_age < self.cache_ttl_seconds,
+            "cache_age_seconds": round(cache_age, 1),
+            "ttl_seconds": self.cache_ttl_seconds,
+        }
+
+    def _should_refresh_alerts(self) -> bool:
+        """
+        Check if alerts should be refreshed.
+
+        Returns:
+            True if enough time has passed since last alert check
+        """
+        if self._last_alert_check is None:
+            return True
+        elapsed = (get_datetime_now() - self._last_alert_check).total_seconds()
+        return elapsed >= self.alert_refresh_interval
+
+    def _maybe_refresh_alerts(self, broker_state: Dict[str, Any]):
+        """
+        Opportunistically refresh alerts if enough time has passed.
+
+        Issue #337 Phase 2: This is called from fetch() to
+        "piggyback" alert checks on broker state fetches without additional API calls.
+
+        Args:
+            broker_state: Current broker state (already fetched)
+        """
+        if not self._should_refresh_alerts():
+            return
+
+        if self.check_alerts_callback is None:
+            return
+
+        try:
+            self._cached_alerts = self.check_alerts_callback(broker_state)
+            self._last_alert_check = get_datetime_now()
+            logger.debug(f"Background alert refresh: {len(self._cached_alerts)} alerts")
+        except Exception as e:
+            logger.warning(f"Failed to refresh alerts: {e}")
+
+    def get_current_alerts(self) -> List[Any]:
+        """
+        Get cached alerts without additional API calls.
+
+        Issue #337 Phase 2: Returns cached alerts. If alerts are stale or missing,
+        triggers a broker state fetch which will refresh alerts via piggyback.
+
+        Returns:
+            List of PositionAlertSummary objects
+        """
+        if not self._cached_alerts or self._should_refresh_alerts():
+            # Trigger broker fetch which will piggyback alert refresh
+            self.fetch()
+
+        return self._cached_alerts

--- a/src/trading/local_state_manager.py
+++ b/src/trading/local_state_manager.py
@@ -1,0 +1,140 @@
+"""
+LocalStateManager - JSON persistence for local trading state.
+
+Extracted from trading_cycle.py as part of #439 refactoring.
+Handles loading/saving position state including position tracker history.
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from src.utils.date_utils import now_iso
+
+logger = logging.getLogger(__name__)
+
+
+class LocalStateManager:
+    """
+    Manages local JSON state persistence for trading positions.
+
+    JSON is for human reference - broker is always source of truth.
+    Persists position tracker state including alert history.
+    """
+
+    def __init__(self, state_file: str, position_tracker: Optional[Any] = None):
+        """
+        Initialize LocalStateManager.
+
+        Args:
+            state_file: Path to JSON state file
+            position_tracker: Optional PositionTracker for alert history persistence
+        """
+        self.state_file = state_file
+        self.position_tracker = position_tracker
+
+        # Ensure state directory exists
+        os.makedirs(os.path.dirname(state_file), exist_ok=True)
+
+        # Load initial state
+        self._state: Dict[str, Any] = self._load()
+
+        logger.info(f"LocalStateManager initialized with state file: {state_file}")
+
+    @property
+    def state(self) -> Dict[str, Any]:
+        """Get current state dict."""
+        return self._state
+
+    @state.setter
+    def state(self, value: Dict[str, Any]):
+        """Set state dict."""
+        self._state = value
+
+    @property
+    def positions(self) -> Dict[str, Any]:
+        """Get positions from state."""
+        return self._state.get("positions", {})
+
+    def _load(self) -> Dict[str, Any]:
+        """Load local JSON state (for human reference)."""
+        if os.path.exists(self.state_file):
+            try:
+                with open(self.state_file, "r") as f:
+                    state = json.load(f)
+
+                # Restore position tracker with alert history if available
+                if self.position_tracker and "position_tracker_state" in state:
+                    try:
+                        self.position_tracker.restore_from_dict(state["position_tracker_state"])
+                        logger.info("Restored position tracker with alert history")
+                    except Exception as e:
+                        logger.warning(f"Failed to restore position tracker state: {e}")
+
+                return state
+            except (json.JSONDecodeError, IOError) as e:
+                logger.warning(f"Failed to load state file: {e}")
+                return self._default_state()
+        return self._default_state()
+
+    def _default_state(self) -> Dict[str, Any]:
+        """Return default empty state."""
+        return {"positions": {}, "last_update": None, "discrepancies": []}
+
+    def save(self):
+        """Save local state to JSON including position tracker with alert history."""
+        self._state["last_update"] = now_iso()
+
+        # Persist position tracker state (including alert history)
+        if self.position_tracker:
+            self._state["position_tracker_state"] = self.position_tracker.to_dict()
+
+        try:
+            with open(self.state_file, "w") as f:
+                json.dump(self._state, f, indent=2)
+
+            position_count = len(self.position_tracker.positions) if self.position_tracker else 0
+            logger.debug(f"Saved local state with {position_count} tracked positions")
+        except IOError as e:
+            logger.error(f"Failed to save state: {e}")
+
+    def reload(self) -> Dict[str, Any]:
+        """Reload state from disk."""
+        self._state = self._load()
+        return self._state
+
+    def get_position(self, symbol: str) -> Optional[Dict[str, Any]]:
+        """Get position data for a symbol."""
+        return self._state.get("positions", {}).get(symbol)
+
+    def set_position(self, symbol: str, position_data: Dict[str, Any]):
+        """Set position data for a symbol."""
+        if "positions" not in self._state:
+            self._state["positions"] = {}
+        self._state["positions"][symbol] = position_data
+
+    def remove_position(self, symbol: str) -> bool:
+        """Remove position from state. Returns True if removed."""
+        if symbol in self._state.get("positions", {}):
+            del self._state["positions"][symbol]
+            return True
+        return False
+
+    def update_position(self, symbol: str, updates: Dict[str, Any]):
+        """Update specific fields in a position."""
+        if symbol in self._state.get("positions", {}):
+            self._state["positions"][symbol].update(updates)
+
+    def set_discrepancies(self, discrepancies: list):
+        """Set discrepancies list."""
+        self._state["discrepancies"] = discrepancies
+
+    def reset_for_recovery(self):
+        """Reset state for crash recovery."""
+        self._state = {
+            "positions": {},
+            "last_update": now_iso(),
+            "discrepancies": [],
+            "recovery_timestamp": now_iso(),
+        }

--- a/src/trading/report_generator.py
+++ b/src/trading/report_generator.py
@@ -1,0 +1,251 @@
+"""
+ReportGenerator - Generate human-readable trading reports.
+
+Extracted from trading_cycle.py as part of #439 refactoring.
+Handles report generation for morning/evening routines.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from src.utils.date_utils import get_datetime_now
+
+logger = logging.getLogger(__name__)
+
+
+class RoutineType(Enum):
+    """Type of trading routine."""
+
+    MORNING = "morning"
+    EVENING = "evening"
+    RECOVERY = "recovery"
+
+
+@dataclass
+class PositionSummary:
+    """Summary of a position for reporting."""
+
+    symbol: str
+    entry_price: float
+    current_price: float
+    stop_price: float
+    target_price: float
+    quantity: int
+    unrealized_pl: float
+    unrealized_percent: float
+    stop_action: str  # "No change", "Move to breakeven", etc.
+
+
+class ReportGenerator:
+    """
+    Generates human-readable trading reports.
+
+    Creates formatted markdown reports for morning/evening routines.
+    """
+
+    def __init__(self):
+        """Initialize ReportGenerator."""
+        logger.info("ReportGenerator initialized")
+
+    def generate_position_summaries(
+        self,
+        broker_state: Dict[str, Any],
+        local_state: Dict[str, Any],
+        adjustments: List[Any],
+    ) -> List[PositionSummary]:
+        """
+        Generate position summaries for reporting.
+
+        Args:
+            broker_state: Current broker state
+            local_state: Current local state
+            adjustments: List of StopAdjustment objects
+
+        Returns:
+            List of PositionSummary objects
+        """
+        summaries = []
+        positions = local_state.get("positions", {})
+
+        # Create adjustment lookup
+        adjustment_map = {adj.symbol: adj for adj in adjustments}
+
+        for symbol, broker_pos in broker_state["positions"].items():
+            if symbol not in positions:
+                continue
+
+            local_pos = positions[symbol]
+            current_price = float(broker_pos.get("current_price") or 0)
+            entry_price = float(local_pos.get("entry_price") or 0)
+            quantity = int(broker_pos.get("quantity") or 0)
+
+            # Calculate P&L
+            unrealized_pl = (current_price - entry_price) * quantity
+            unrealized_percent = ((current_price - entry_price) / entry_price) if entry_price else 0
+
+            # Determine stop action
+            stop_action = "No change"
+            if symbol in adjustment_map:
+                stop_action = adjustment_map[symbol].reason
+
+            summaries.append(
+                PositionSummary(
+                    symbol=symbol,
+                    entry_price=entry_price,
+                    current_price=current_price,
+                    stop_price=float(local_pos.get("stop_price") or 0),
+                    target_price=float(local_pos.get("target_price") or 0),
+                    quantity=quantity,
+                    unrealized_pl=unrealized_pl,
+                    unrealized_percent=unrealized_percent,
+                    stop_action=stop_action,
+                )
+            )
+
+        return summaries
+
+    def generate_routine_report(
+        self,
+        routine_type: RoutineType,
+        broker_state: Dict[str, Any],
+        local_state: Dict[str, Any],
+        discrepancies: List[Any],
+        adjustments: List[Any],
+        alerts: Optional[List[Any]] = None,
+        modification_results: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """
+        Generate human-readable trading report with alerts.
+
+        Args:
+            routine_type: Type of routine (morning/evening/recovery)
+            broker_state: Current broker state
+            local_state: Current local state
+            discrepancies: List of Discrepancy objects
+            adjustments: List of StopAdjustment objects
+            alerts: Optional list of PositionAlertSummary objects
+            modification_results: Optional results from batch order modifications
+
+        Returns:
+            Formatted markdown report string
+        """
+        now = get_datetime_now()
+        report_lines = [
+            f"# {routine_type.value.title()} Trading Report - {now.strftime('%Y-%m-%d %H:%M:%S')}",
+            "",
+        ]
+
+        # Account summary
+        account = broker_state.get("account", {})
+        portfolio_value = float(account.get("portfolio_value") or 0)
+        cash = float(account.get("cash") or 0)
+        buying_power = float(account.get("buying_power") or 0)
+
+        report_lines.extend(
+            [
+                "## Account Summary",
+                f"Portfolio Value: ${portfolio_value:,.2f}",
+                f"Available Cash: ${cash:,.2f}",
+                f"Buying Power: ${buying_power:,.2f}",
+                "",
+            ]
+        )
+
+        # Position summaries
+        summaries = self.generate_position_summaries(broker_state, local_state, adjustments)
+        if summaries:
+            report_lines.extend(
+                [
+                    "## Active Positions",
+                    "| Symbol | Entry | Current | Stop | Target | P&L | Action |",
+                    "|--------|-------|---------|------|--------|-----|--------|",
+                ]
+            )
+
+            for summary in summaries:
+                pl_sign = "+" if summary.unrealized_pl >= 0 else ""
+                pl_str = f"{pl_sign}${summary.unrealized_pl:.0f} ({summary.unrealized_percent:.1%})"
+                report_lines.append(
+                    f"| {summary.symbol} | ${summary.entry_price:.2f} | "
+                    f"${summary.current_price:.2f} | ${summary.stop_price:.2f} | "
+                    f"${summary.target_price:.2f} | {pl_str} | {summary.stop_action} |"
+                )
+            report_lines.append("")
+        else:
+            report_lines.extend(["## Active Positions", "No active positions", ""])
+
+        # Discrepancies
+        if discrepancies:
+            report_lines.extend(["## Discrepancies Found"])
+            for disc in discrepancies:
+                severity_emoji = {"HIGH": "🚨", "MEDIUM": "⚠️", "LOW": "ℹ️"}.get(disc.severity, "ℹ️")
+                report_lines.append(f"{severity_emoji} {disc.type}: {disc.symbol}")
+
+                if disc.type == "UNKNOWN_POSITION":
+                    qty = disc.details["broker_quantity"]
+                    entry = disc.details["broker_entry"]
+                    report_lines.append(f"   {qty} shares at ${entry:.2f} - {disc.action}")
+                elif disc.type == "GHOST_POSITION":
+                    qty = disc.details["local_quantity"]
+                    report_lines.append(f"   Phantom {qty} shares - {disc.action}")
+                elif disc.type == "QUANTITY_MISMATCH":
+                    broker_qty = disc.details["broker_quantity"]
+                    local_qty = disc.details["local_quantity"]
+                    report_lines.append(
+                        f"   Broker: {broker_qty}, Local: {local_qty} - {disc.action}"
+                    )
+
+                report_lines.append("")
+
+        # Position Alerts
+        if alerts:
+            report_lines.extend(["## Position Alerts"])
+            # Count by severity
+            critical_count = len([a for a in alerts if a.severity == "CRITICAL"])
+            warning_count = len([a for a in alerts if a.severity == "WARNING"])
+            info_count = len([a for a in alerts if a.severity == "INFO"])
+
+            report_lines.append(
+                f"Total Alerts: {len(alerts)} "
+                f"({critical_count} Critical, {warning_count} Warning, {info_count} Info)"
+            )
+            report_lines.append("")
+
+            for alert in alerts:
+                report_lines.append(alert.message)
+
+            report_lines.append("")
+
+        # Stop modifications
+        if modification_results:
+            report_lines.extend(["## Stop Adjustments"])
+            if modification_results["modifications"] > 0:
+                report_lines.append(
+                    f"✅ {modification_results['modifications']} stops adjusted successfully"
+                )
+
+            if modification_results["errors"]:
+                report_lines.append("❌ Errors:")
+                for error in modification_results["errors"]:
+                    report_lines.append(f"   {error}")
+            report_lines.append("")
+
+        # Footer
+        next_routine = "evening" if routine_type == RoutineType.MORNING else "morning"
+        next_time = "15:50:00" if routine_type == RoutineType.MORNING else "09:20:00"
+        report_lines.extend(
+            [
+                "---",
+                f"Generated: {now.strftime('%Y-%m-%d %H:%M:%S')}",
+                f"Next {next_routine} routine: {next_time}",
+                "Cost: ~3-5 API calls total",
+                "",
+                "**Note**: Stop prices calculated from entry price "
+                "(Alpaca hides bracket order stop-loss legs from API).",
+                "Verify stop orders exist on Alpaca dashboard. See Issue #355.",
+            ]
+        )
+
+        return "\n".join(report_lines)

--- a/src/trading/state_reconciler.py
+++ b/src/trading/state_reconciler.py
@@ -1,0 +1,475 @@
+"""
+StateReconciler - Reconcile local state with broker reality.
+
+Extracted from trading_cycle.py as part of #439 refactoring.
+Handles state reconciliation, stop adjustments, and position alerts.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from src.utils.date_utils import now_iso
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Discrepancy:
+    """Represents a mismatch between local state and broker reality."""
+
+    type: str  # UNKNOWN_POSITION, GHOST_POSITION, ORDER_MISMATCH, QUANTITY_MISMATCH
+    symbol: str
+    details: Dict[str, Any]
+    action: str  # NEEDS_HUMAN_REVIEW, AUTO_FIXED, REMOVED_FROM_JSON
+    severity: str = "MEDIUM"  # LOW, MEDIUM, HIGH
+
+
+@dataclass
+class StopAdjustment:
+    """Represents a stop order modification needed."""
+
+    symbol: str
+    order_id: str
+    current_stop: float
+    new_stop: float
+    reason: str
+    profit_percent: float
+
+
+@dataclass
+class PositionAlertSummary:
+    """Summary of position alerts for reporting."""
+
+    symbol: str
+    alert_type: str
+    severity: str
+    message: str
+    timestamp: str
+    current_price: float
+    details: Dict[str, Any]
+
+
+class StateReconciler:
+    """
+    Reconciles local JSON state with broker reality.
+
+    Broker is always source of truth. Local JSON is for human reference.
+    """
+
+    def __init__(
+        self,
+        config: Any,
+        trailing_stop_manager: Optional[Any] = None,
+        position_tracker: Optional[Any] = None,
+    ):
+        """
+        Initialize StateReconciler.
+
+        Args:
+            config: TradingConfig for risk parameters
+            trailing_stop_manager: TrailingStopManager for stop calculations
+            position_tracker: PositionTracker for alert checking
+        """
+        self.config = config
+        self.trailing_stop_manager = trailing_stop_manager
+        self.position_tracker = position_tracker
+
+        logger.info("StateReconciler initialized")
+
+    def reconcile(
+        self,
+        broker_state: Dict[str, Any],
+        local_state: Dict[str, Any],
+    ) -> tuple[List[Discrepancy], Dict[str, Any]]:
+        """
+        Reconcile local JSON with broker reality.
+        JSON is for humans, broker is truth.
+
+        Args:
+            broker_state: Current state from broker
+            local_state: Current local JSON state
+
+        Returns:
+            Tuple of (discrepancies list, updated local_state)
+        """
+        discrepancies = []
+        positions = local_state.get("positions", {})
+
+        # Check for unknown positions (at broker but not in local JSON)
+        for symbol, broker_pos in broker_state["positions"].items():
+            if symbol not in positions:
+                discrepancies.append(
+                    Discrepancy(
+                        type="UNKNOWN_POSITION",
+                        symbol=symbol,
+                        details={
+                            "broker_quantity": broker_pos["quantity"],
+                            "broker_entry": broker_pos["entry_price"],
+                            "current_price": broker_pos["current_price"],
+                        },
+                        action="NEEDS_HUMAN_REVIEW",
+                        severity="HIGH",
+                    )
+                )
+
+                # Extract stop/target prices from broker's open orders
+                entry_price = broker_pos["entry_price"]
+                stop_price, target_price, _ = self._extract_stop_target_from_orders(
+                    symbol, broker_state, entry_price=entry_price, local_state=local_state
+                )
+
+                # Auto-add to local state for tracking
+                positions[symbol] = {
+                    "entry_price": broker_pos["entry_price"],
+                    "quantity": broker_pos["quantity"],
+                    "entry_time": now_iso(),
+                    "source": "AUTO_DISCOVERED",
+                    "stop_price": stop_price,
+                    "target_price": target_price,
+                }
+
+        # Check for ghost positions (in local JSON but not at broker)
+        for symbol in list(positions.keys()):
+            if symbol not in broker_state["positions"]:
+                local_pos = positions[symbol]
+                discrepancies.append(
+                    Discrepancy(
+                        type="GHOST_POSITION",
+                        symbol=symbol,
+                        details={
+                            "local_quantity": local_pos.get("quantity", 0),
+                            "local_entry": local_pos.get("entry_price", 0),
+                        },
+                        action="REMOVED_FROM_JSON",
+                        severity="MEDIUM",
+                    )
+                )
+
+                # Remove ghost position
+                del positions[symbol]
+
+        # Check quantity mismatches
+        for symbol in broker_state["positions"]:
+            if symbol in positions:
+                broker_qty = broker_state["positions"][symbol]["quantity"]
+                local_qty = positions[symbol].get("quantity", 0)
+
+                if broker_qty != local_qty:
+                    discrepancies.append(
+                        Discrepancy(
+                            type="QUANTITY_MISMATCH",
+                            symbol=symbol,
+                            details={
+                                "broker_quantity": broker_qty,
+                                "local_quantity": local_qty,
+                                "difference": broker_qty - local_qty,
+                            },
+                            action="AUTO_FIXED",
+                            severity="LOW",
+                        )
+                    )
+
+                    # Fix quantity
+                    positions[symbol]["quantity"] = broker_qty
+
+        # Sync stop/target prices from broker orders for all positions
+        for symbol in broker_state["positions"]:
+            if symbol in positions:
+                entry_price = positions[symbol].get("entry_price")
+                stop_price, target_price, _ = self._extract_stop_target_from_orders(
+                    symbol, broker_state, entry_price=entry_price, local_state=local_state
+                )
+
+                # Update local state with broker's stop/target prices
+                local_pos = positions[symbol]
+                local_stop = local_pos.get("stop_price")
+                local_target = local_pos.get("target_price")
+
+                # Only log discrepancy if there was a change
+                if stop_price != local_stop or target_price != local_target:
+                    logger.info(
+                        f"{symbol}: Syncing stop/target from orders - "
+                        f"stop: {local_stop} -> {stop_price}, "
+                        f"target: {local_target} -> {target_price}"
+                    )
+                    local_pos["stop_price"] = stop_price
+                    local_pos["target_price"] = target_price
+
+        local_state["positions"] = positions
+        logger.info(f"Reconciliation found {len(discrepancies)} discrepancies")
+        return discrepancies, local_state
+
+    def _extract_stop_target_from_orders(
+        self,
+        symbol: str,
+        broker_state: Dict[str, Any],
+        entry_price: float = None,
+        local_state: Dict[str, Any] = None,
+    ) -> tuple:
+        """
+        Extract stop_price and target_price from broker's open orders for a symbol.
+
+        If orders can't be found (Alpaca hides "held" stop orders), calculate expected
+        stop from entry price and strategy config.
+
+        Args:
+            symbol: Ticker symbol
+            broker_state: Current broker state with orders
+            entry_price: Position entry price (for calculating expected stop if not found)
+            local_state: Local state for saved stop values
+
+        Returns:
+            (stop_price, target_price, stop_verified) tuple
+            - stop_verified: True if stop found in API, False if calculated
+        """
+        stop_price = None
+        target_price = None
+        stop_verified = False
+
+        if symbol in broker_state.get("orders", {}):
+            logger.debug(f"{symbol}: Found {len(broker_state['orders'][symbol])} orders")
+            for order in broker_state["orders"][symbol]:
+                order_type = order.get("type", "")
+                side = order.get("side", "")
+
+                # Convert enums to strings for comparison
+                side_str = str(side).lower() if side else ""
+                order_type_str = str(order_type).lower() if order_type else ""
+
+                logger.debug(
+                    f"  Order: type={order_type_str}, side={side_str}, "
+                    f"stop={order.get('stop_price')}, limit={order.get('limit_price')}"
+                )
+
+                # Stop-loss order: sell order with stop_price set (for long positions)
+                if "sell" in side_str and order.get("stop_price"):
+                    stop_price = order["stop_price"]
+                    stop_verified = True
+                    logger.debug(f"  -> Found stop_price: {stop_price}")
+
+                # Take-profit order: sell order with limit_price set (for long positions)
+                elif "sell" in side_str and order.get("limit_price"):
+                    target_price = order["limit_price"]
+                    logger.debug(f"  -> Found target_price: {target_price}")
+        else:
+            logger.debug(f"{symbol}: No orders found in broker_state")
+
+        # If stop not found via API, try to use saved value from local state first
+        if not stop_price and local_state:
+            positions = local_state.get("positions", {})
+            if symbol in positions:
+                saved_stop = positions[symbol].get("stop_price")
+                if saved_stop:
+                    stop_price = saved_stop
+                    logger.info(f"{symbol}: Using saved stop price from local state: ${stop_price}")
+
+        # Last resort: calculate from entry price if we have no saved value
+        if not stop_price and entry_price:
+            stop_loss_pct = self.config.get_risk_config("stop_loss")
+            calculated_stop = round(entry_price * (1 - stop_loss_pct), 2)
+            stop_price = calculated_stop
+            logger.warning(
+                f"{symbol}: Stop order hidden by Alpaca API, no saved value found. "
+                f"Calculated from entry: ${calculated_stop}. "
+                f"Verify actual stop on Alpaca dashboard."
+            )
+
+        logger.info(
+            f"{symbol}: Extracted stop=${stop_price} (verified={stop_verified}), "
+            f"target=${target_price}"
+        )
+
+        return stop_price, target_price, stop_verified
+
+    def calculate_stop_adjustments(
+        self,
+        broker_state: Dict[str, Any],
+        local_state: Dict[str, Any],
+    ) -> tuple[List[StopAdjustment], Dict[str, Any]]:
+        """
+        Calculate which stops need adjustment based on current prices.
+
+        Uses TrailingStopManager for progressive stop logic calculation.
+
+        Args:
+            broker_state: Current broker state
+            local_state: Current local state
+
+        Returns:
+            Tuple of (adjustments list, updated local_state)
+        """
+        if self.trailing_stop_manager is None:
+            logger.warning("No trailing stop manager configured")
+            return [], local_state
+
+        adjustments = []
+        positions = local_state.get("positions", {})
+
+        for symbol, broker_pos in broker_state["positions"].items():
+            if symbol not in positions:
+                continue  # Skip unknown positions
+
+            local_pos = positions[symbol]
+            entry_price = float(local_pos.get("entry_price", 0))
+            current_price = broker_pos["current_price"]
+            current_stop = local_pos.get("stop_price")
+            quantity = int(broker_pos.get("quantity", 0))
+
+            if not entry_price or not current_stop:
+                continue  # No entry price or stop to adjust
+
+            # Register position with TrailingStopManager if not already tracked
+            if symbol not in self.trailing_stop_manager.stop_states:
+                self.trailing_stop_manager.register_position(
+                    symbol=symbol,
+                    entry_price=entry_price,
+                    initial_stop=current_stop,
+                    quantity=quantity,
+                    stop_order_id=None,
+                )
+
+            # Use TrailingStopManager to calculate new stop price
+            new_stop = self.trailing_stop_manager.calculate_new_stop(symbol, current_price)
+
+            if new_stop is None:
+                continue  # No adjustment needed
+
+            # Calculate profit percentage for reporting
+            profit_percent = (current_price - entry_price) / entry_price
+
+            # Determine reason based on profit level (for reporting)
+            if profit_percent < 0.04:
+                reason = f"Move to breakeven ({profit_percent:.1%} profit)"
+            elif profit_percent < 0.06:
+                reason = f"Lock 25% gains ({profit_percent:.1%} profit)"
+            else:
+                reason = f"Trail 50% gains ({profit_percent:.1%} profit)"
+
+            logger.info(f"{symbol}: Stop adjustment recommended - {reason}")
+
+            # Only adjust if new stop is higher than current stop
+            if new_stop > current_stop + 0.01:  # $0.01 minimum move
+                # Find the stop order ID from broker orders
+                stop_order_id = None
+                if symbol in broker_state.get("orders", {}):
+                    for order in broker_state["orders"][symbol]:
+                        if order["type"] in ["stop", "stop_loss"] and order["side"] == "sell":
+                            stop_order_id = order["id"]
+                            logger.debug(f"{symbol}: Found stop order ID {stop_order_id}")
+                            break
+
+                if stop_order_id:
+                    adjustment_amount = new_stop - current_stop
+                    adjustment_pct = (adjustment_amount / current_stop) * 100
+                    logger.info(
+                        f"{symbol}: Creating stop adjustment - "
+                        f"${current_stop:.2f} → ${new_stop:.2f} "
+                        f"(+${adjustment_amount:.2f}, +{adjustment_pct:.1f}%)"
+                    )
+
+                    adjustments.append(
+                        StopAdjustment(
+                            symbol=symbol,
+                            order_id=stop_order_id,
+                            current_stop=current_stop,
+                            new_stop=new_stop,
+                            reason=reason,
+                            profit_percent=profit_percent,
+                        )
+                    )
+
+                    # Update local state
+                    positions[symbol]["stop_price"] = new_stop
+
+                    # Update TrailingStopManager state to stay in sync
+                    if symbol in self.trailing_stop_manager.stop_states:
+                        self.trailing_stop_manager.stop_states[symbol].current_stop = new_stop
+                else:
+                    logger.warning(
+                        f"{symbol}: Stop adjustment needed but no stop order found in broker orders"
+                    )
+            else:
+                logger.debug(
+                    f"{symbol}: New stop ${new_stop:.2f} not significantly higher "
+                    f"than current ${current_stop:.2f}"
+                )
+
+        local_state["positions"] = positions
+        logger.info(f"Found {len(adjustments)} stop adjustments needed")
+        return adjustments, local_state
+
+    def check_position_alerts(
+        self,
+        broker_state: Dict[str, Any],
+        local_state: Dict[str, Any],
+    ) -> List[PositionAlertSummary]:
+        """
+        Check all positions for exit alerts (approaching TP/SL).
+
+        Args:
+            broker_state: Current broker state with positions
+            local_state: Current local state
+
+        Returns:
+            List of position alerts
+        """
+        if self.position_tracker is None:
+            logger.warning("No position tracker configured")
+            return []
+
+        alerts = []
+        positions = local_state.get("positions", {})
+
+        for symbol, broker_pos in broker_state["positions"].items():
+            if symbol not in positions:
+                continue  # Skip unknown positions
+
+            local_pos = positions[symbol]
+            entry_price = float(local_pos.get("entry_price", 0))
+            current_price = broker_pos["current_price"]
+            take_profit_price = local_pos.get("target_price")
+            stop_loss_price = local_pos.get("stop_price")
+
+            if not entry_price or not take_profit_price or not stop_loss_price:
+                continue  # Skip positions without complete data
+
+            # Create or update position in tracker
+            position_id = f"{symbol}_{entry_price}"
+            try:
+                if position_id not in self.position_tracker.positions:
+                    # Create position for tracking
+                    self.position_tracker.create_position(
+                        ticker=symbol, entry_price=entry_price, quantity=broker_pos["quantity"]
+                    )
+                    # Manually set TP/SL prices to match configured values
+                    if position_id in self.position_tracker.positions:
+                        position = self.position_tracker.positions[position_id]
+                        position.take_profit_price = take_profit_price
+                        position.stop_loss_price = stop_loss_price
+
+                # Check for exit conditions/alerts
+                exit_check = self.position_tracker.check_exit_conditions(position_id, current_price)
+
+                if exit_check and exit_check.get("recommendation") == "ALERT":
+                    # Get the most recent alert for this position
+                    if position_id in self.position_tracker.positions:
+                        position = self.position_tracker.positions[position_id]
+                        if position.alert_history:
+                            recent_alert = position.alert_history[-1]
+                            alerts.append(
+                                PositionAlertSummary(
+                                    symbol=symbol,
+                                    alert_type=recent_alert.alert_type.value,
+                                    severity=recent_alert.severity,
+                                    message=recent_alert.format_message(),
+                                    timestamp=recent_alert.timestamp.isoformat(),
+                                    current_price=current_price,
+                                    details=recent_alert.details,
+                                )
+                            )
+            except (KeyError, Exception) as e:
+                logger.warning(f"Position tracker error for {symbol}: {e}")
+
+        logger.info(f"Found {len(alerts)} position alerts")
+        return alerts

--- a/src/trading/trading_cycle.py
+++ b/src/trading/trading_cycle.py
@@ -7,89 +7,48 @@ Core Principle: Let the broker do the work via GTC orders, minimize LLM/API call
 - Evening routine: 3:50 PM ET - EOD review and preparation
 - Batch all API calls to minimize costs
 - JSON is for humans, broker is truth
+
+Refactored in #439 to use extracted components:
+- LocalStateManager: JSON persistence
+- BrokerStateCache: Broker state caching
+- StateReconciler: Reconciliation logic
+- ReportGenerator: Report formatting
 """
 
-import json
 import logging
 import os
-import sys
-from dataclasses import asdict, dataclass
-from datetime import datetime
-from enum import Enum
-from typing import Any, Dict, List, Optional
+from dataclasses import asdict
+from typing import Any, Dict, List
 
 import yaml
-
-from src.utils.date_utils import get_datetime_now, now_iso
-
-# Add project root to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 from config_defaults.trading_config import TradingConfig
 
 from src.data_sources.sources.market.alpaca_market_data import AlpacaMarketData
 from src.trading.alpaca_trading_client import AlpacaAccountMonitor, AlpacaOrderManager
+from src.trading.broker_state_cache import BrokerStateCache
+from src.trading.local_state_manager import LocalStateManager
+from src.trading.report_generator import ReportGenerator, RoutineType
+from src.trading.state_reconciler import (
+    Discrepancy,
+    PositionAlertSummary,
+    StateReconciler,
+    StopAdjustment,
+)
 from src.trading.trailing_stop_manager import TrailingStopManager
 from src.trading_tools.position_tracker import PositionTracker
+from src.utils.date_utils import get_datetime_now
 
 logger = logging.getLogger(__name__)
 
-
-@dataclass
-class Discrepancy:
-    """Represents a mismatch between local state and broker reality"""
-
-    type: str  # UNKNOWN_POSITION, GHOST_POSITION, ORDER_MISMATCH
-    symbol: str
-    details: Dict[str, Any]
-    action: str  # NEEDS_HUMAN_REVIEW, AUTO_FIXED, REMOVED_FROM_JSON
-    severity: str = "MEDIUM"  # LOW, MEDIUM, HIGH
-
-
-@dataclass
-class StopAdjustment:
-    """Represents a stop order modification needed"""
-
-    symbol: str
-    order_id: str
-    current_stop: float
-    new_stop: float
-    reason: str
-    profit_percent: float
-
-
-@dataclass
-class PositionAlertSummary:
-    """Summary of position alerts for reporting"""
-
-    symbol: str
-    alert_type: str
-    severity: str
-    message: str
-    timestamp: str
-    current_price: float
-    details: Dict[str, Any]
-
-
-@dataclass
-class PositionSummary:
-    """Summary of a position for reporting"""
-
-    symbol: str
-    entry_price: float
-    current_price: float
-    stop_price: float
-    target_price: float
-    quantity: int
-    unrealized_pl: float
-    unrealized_percent: float
-    stop_action: str  # "No change", "Move to breakeven", etc.
-
-
-class RoutineType(Enum):
-    MORNING = "morning"
-    EVENING = "evening"
-    RECOVERY = "recovery"
+# Re-export dataclasses for backward compatibility
+__all__ = [
+    "CostEfficientTradeCycle",
+    "Discrepancy",
+    "StopAdjustment",
+    "PositionAlertSummary",
+    "RoutineType",
+]
 
 
 class CostEfficientTradeCycle:
@@ -102,6 +61,12 @@ class CostEfficientTradeCycle:
     - Batch all modifications into single API calls
     - Generate human-readable reports for oversight
     - Crash recovery rebuilds state from broker truth
+
+    Components (extracted in #439):
+    - LocalStateManager: JSON state persistence
+    - BrokerStateCache: Cached broker state with TTL
+    - StateReconciler: Reconciliation and alert logic
+    - ReportGenerator: Human-readable reports
     """
 
     def __init__(self, state_file: str = None):
@@ -114,7 +79,6 @@ class CostEfficientTradeCycle:
                 logger.info(f"Loaded paths config from {config_path}")
         except FileNotFoundError:
             logger.warning(f"Paths config not found at {config_path}, using hardcoded defaults")
-            # Fallback to hardcoded defaults
             self.paths = {
                 "state_files": {"cost_efficient": "state/cost_efficient_positions.json"},
                 "report_templates": {"daily_routine": "reports/daily/{date}_{routine_type}.md"},
@@ -125,8 +89,8 @@ class CostEfficientTradeCycle:
             state_file = self.paths.get("state_files", {}).get(
                 "cost_efficient", "state/cost_efficient_positions.json"
             )
-        self.state_file = state_file
 
+        # Initialize market data and account services
         self.market_data = AlpacaMarketData()
         self.account_monitor = AlpacaAccountMonitor(mode="paper")
         self.order_manager = AlpacaOrderManager(mode="paper")
@@ -142,636 +106,136 @@ class CostEfficientTradeCycle:
         )
 
         # Initialize trailing stop manager for dynamic stop adjustments
-        # Note: Uses None for order_manager since we use batch_modify_orders() for broker calls
         self.trailing_stop_manager = TrailingStopManager(
             order_manager=None,  # We handle broker calls separately via batch_modify_orders()
             config=self.config,
         )
 
-        # Ensure state directory exists
-        os.makedirs(os.path.dirname(state_file), exist_ok=True)
-
-        # Load local state
-        self.local_state = self.load_local_state()
-
-        # Issue #337: Broker state caching to reduce API calls
-        self.broker_state_cache: Optional[Dict[str, Any]] = None
-        self.cache_timestamp: Optional[datetime] = None
-        self.cache_ttl_seconds: int = 60  # 1 minute cache TTL
-
-        # Issue #337 Phase 2: Piggyback alert updates
-        self.cached_alerts: List[Any] = []  # PositionAlertSummary objects
-        self.last_alert_check: Optional[datetime] = None
-        self.alert_refresh_interval: int = 300  # 5 minutes between alert checks
-
-        logger.info("CostEfficientTradeCycle initialized with alert monitoring and state caching")
-
-    def load_local_state(self) -> Dict[str, Any]:
-        """Load local JSON state (for human reference)"""
-        if os.path.exists(self.state_file):
-            try:
-                with open(self.state_file, "r") as f:
-                    state = json.load(f)
-
-                # Restore position tracker with alert history
-                if "position_tracker_state" in state:
-                    try:
-                        self.position_tracker.restore_from_dict(state["position_tracker_state"])
-                        logger.info("Restored position tracker with alert history")
-                    except Exception as e:
-                        logger.warning(f"Failed to restore position tracker state: {e}")
-
-                return state
-            except (json.JSONDecodeError, IOError) as e:
-                logger.warning(f"Failed to load state file: {e}")
-                return {"positions": {}, "last_update": None, "discrepancies": []}
-        return {"positions": {}, "last_update": None, "discrepancies": []}
-
-    def save_local_state(self):
-        """Save local state to JSON including position tracker with alert history"""
-        self.local_state["last_update"] = now_iso()
-
-        # Persist position tracker state (including alert history)
-        self.local_state["position_tracker_state"] = self.position_tracker.to_dict()
-
-        try:
-            with open(self.state_file, "w") as f:
-                json.dump(self.local_state, f, indent=2)
-            logger.debug(
-                f"Saved local state with {len(self.position_tracker.positions)} tracked positions"
-            )
-        except IOError as e:
-            logger.error(f"Failed to save state: {e}")
-
-    def fetch_broker_state(self, force_refresh: bool = False) -> Dict[str, Any]:
-        """
-        Get all positions and orders from broker with smart caching.
-        This is the source of truth.
-
-        Issue #337: Added caching to reduce API calls. Cache TTL is 60 seconds.
-
-        Args:
-            force_refresh: If True, bypass cache and fetch fresh data from broker
-
-        Returns:
-            Dict with positions, orders, account info, and timestamp
-        """
-        # Check if cached data is still valid
-        if not force_refresh and self.broker_state_cache is not None:
-            cache_age = (get_datetime_now() - self.cache_timestamp).total_seconds()
-            if cache_age < self.cache_ttl_seconds:
-                logger.debug(f"Using cached broker state (age: {cache_age:.1f}s)")
-                return self.broker_state_cache
-
-        logger.debug("Cache miss or force_refresh - fetching from broker")
-
-        try:
-            # Get all positions (one API call)
-            positions = self.account_monitor.get_positions()
-
-            # Get all orders (one API call)
-            # Use 'all' to include pending_new, accepted, and other statuses
-            orders = self.account_monitor.get_orders(status="all")
-
-            # Get account info (one API call)
-            account = self.account_monitor.get_account_status()
-
-            # Organize into clean structure
-            broker_state = {
-                "positions": {},
-                "orders": {},
-                "account": {
-                    "buying_power": float(account.get("buying_power", 0)),
-                    "portfolio_value": float(account.get("portfolio_value", 0)),
-                    "cash": float(account.get("cash", 0)),
-                },
-                "timestamp": now_iso(),
-            }
-
-            # Process positions
-            for pos in positions:
-                symbol = pos["symbol"]
-                broker_state["positions"][symbol] = {
-                    "symbol": symbol,
-                    "quantity": int(pos["qty"]),
-                    "entry_price": float(pos["avg_entry_price"]),
-                    "current_price": float(pos["market_value"]) / abs(int(pos["qty"])),
-                    "unrealized_pl": float(pos["unrealized_pl"]),
-                    "side": pos["side"],  # long/short
-                }
-
-            # Process orders (group by symbol)
-            # Only include active orders (not filled, cancelled, expired, etc.)
-            active_statuses = ["new", "pending_new", "accepted", "partially_filled", "held"]
-
-            for order in orders:
-                # Filter to only active orders
-                order_status = str(order.get("status", "")).lower()
-                if not any(status in order_status for status in active_statuses):
-                    continue  # Skip filled, cancelled, expired orders
-
-                symbol = order["symbol"]
-                if symbol not in broker_state["orders"]:
-                    broker_state["orders"][symbol] = []
-
-                # Convert enums to strings for consistent comparison
-                order_entry = {
-                    "id": order["id"],
-                    "type": str(order["order_type"]),  # Convert enum to string
-                    "side": str(order["side"]),  # Convert enum to string
-                    "quantity": int(order["qty"]),
-                    "limit_price": (
-                        float(order.get("limit_price", 0)) if order.get("limit_price") else None
-                    ),
-                    "stop_price": (
-                        float(order.get("stop_price", 0)) if order.get("stop_price") else None
-                    ),
-                    "status": str(order["status"]),  # Convert enum to string
-                    "time_in_force": str(order["time_in_force"]),  # Convert enum to string
-                }
-                broker_state["orders"][symbol].append(order_entry)
-                logger.debug(f"Order {symbol}: {order_entry}")
-
-                # Process bracket order legs (stop-loss and take-profit)
-                if "legs" in order and order["legs"]:
-                    for leg in order["legs"]:
-                        leg_status = str(leg.get("status", "")).lower()
-                        if not any(status in leg_status for status in active_statuses):
-                            continue  # Skip inactive legs
-
-                        leg_entry = {
-                            "id": leg["id"],
-                            "type": str(leg["order_type"]),
-                            "side": str(leg["side"]),
-                            "quantity": int(leg["qty"]),
-                            "limit_price": (
-                                float(leg.get("limit_price", 0)) if leg.get("limit_price") else None
-                            ),
-                            "stop_price": (
-                                float(leg.get("stop_price", 0)) if leg.get("stop_price") else None
-                            ),
-                            "status": str(leg["status"]),
-                            "time_in_force": str(leg["time_in_force"]),
-                            "parent_order_id": order["id"],  # Track parent relationship
-                        }
-                        broker_state["orders"][symbol].append(leg_entry)
-                        logger.debug(f"  Bracket leg {symbol}: {leg_entry}")
-
-            logger.info(
-                f"Fetched broker state: {len(broker_state['positions'])} positions, "
-                f"{len(broker_state['orders'])} order groups, "
-                f"total {len(orders)} orders"
-            )
-
-            # Issue #337: Cache the broker state
-            self.broker_state_cache = broker_state
-            self.cache_timestamp = get_datetime_now()
-
-            # Issue #337 Phase 2: Piggyback alert check if enough time has passed
-            self._maybe_refresh_alerts(broker_state)
-
-            return broker_state
-
-        except Exception as e:
-            logger.error(f"Failed to fetch broker state: {e}")
-            raise
-
-    def invalidate_broker_cache(self):
-        """
-        Invalidate the broker state cache.
-
-        Issue #337: Call this after placing/modifying/cancelling orders
-        to ensure the next fetch_broker_state() gets fresh data.
-        """
-        self.broker_state_cache = None
-        self.cache_timestamp = None
-        logger.debug("Broker state cache invalidated")
-
-    def get_cache_stats(self) -> Dict[str, Any]:
-        """
-        Get cache statistics for debugging/monitoring.
-
-        Returns:
-            Dict with cache_valid, cache_age_seconds, ttl_seconds
-        """
-        if self.broker_state_cache is None:
-            return {
-                "cache_valid": False,
-                "cache_age_seconds": None,
-                "ttl_seconds": self.cache_ttl_seconds,
-            }
-
-        cache_age = (get_datetime_now() - self.cache_timestamp).total_seconds()
-        return {
-            "cache_valid": cache_age < self.cache_ttl_seconds,
-            "cache_age_seconds": round(cache_age, 1),
-            "ttl_seconds": self.cache_ttl_seconds,
-        }
-
-    def _should_refresh_alerts(self) -> bool:
-        """
-        Check if alerts should be refreshed.
-
-        Returns:
-            True if enough time has passed since last alert check
-        """
-        if self.last_alert_check is None:
-            return True
-        elapsed = (get_datetime_now() - self.last_alert_check).total_seconds()
-        return elapsed >= self.alert_refresh_interval
-
-    def _maybe_refresh_alerts(self, broker_state: Dict[str, Any]):
-        """
-        Opportunistically refresh alerts if enough time has passed.
-
-        Issue #337 Phase 2: This is called from fetch_broker_state() to
-        "piggyback" alert checks on broker state fetches without additional API calls.
-
-        Args:
-            broker_state: Current broker state (already fetched)
-        """
-        if not self._should_refresh_alerts():
-            return
-
-        try:
-            self.cached_alerts = self.check_position_alerts(broker_state)
-            self.last_alert_check = get_datetime_now()
-            logger.debug(f"Background alert refresh: {len(self.cached_alerts)} alerts")
-        except Exception as e:
-            logger.warning(f"Failed to refresh alerts: {e}")
-
-    def get_current_alerts(self) -> List[Any]:
-        """
-        Get cached alerts without additional API calls.
-
-        Issue #337 Phase 2: Returns cached alerts. If alerts are stale or missing,
-        triggers a broker state fetch which will refresh alerts via piggyback.
-
-        Returns:
-            List of PositionAlertSummary objects
-        """
-        if not self.cached_alerts or self._should_refresh_alerts():
-            # Trigger broker fetch which will piggyback alert refresh
-            self.fetch_broker_state()
-
-        return self.cached_alerts
-
-    def _extract_stop_target_from_orders(
-        self, symbol: str, broker_state: Dict[str, Any], entry_price: float = None
-    ) -> tuple:
-        """
-        Extract stop_price and target_price from broker's open orders for a symbol.
-
-        If orders can't be found (Alpaca hides "held" stop orders), calculate expected
-        stop from entry price and strategy config.
-
-        Args:
-            symbol: Ticker symbol
-            broker_state: Current broker state with orders
-            entry_price: Position entry price (for calculating expected stop if not found)
-
-        Returns:
-            (stop_price, target_price, stop_verified) tuple
-            - stop_verified: True if stop found in API, False if calculated
-        """
-        stop_price = None
-        target_price = None
-        stop_verified = False
-
-        if symbol in broker_state["orders"]:
-            logger.debug(f"{symbol}: Found {len(broker_state['orders'][symbol])} orders")
-            for order in broker_state["orders"][symbol]:
-                order_type = order.get("type", "")
-                side = order.get("side", "")
-
-                # Convert enums to strings for comparison
-                side_str = str(side).lower() if side else ""
-                order_type_str = str(order_type).lower() if order_type else ""
-
-                logger.debug(
-                    f"  Order: type={order_type_str}, side={side_str}, "
-                    f"stop={order.get('stop_price')}, limit={order.get('limit_price')}"
-                )
-
-                # Stop-loss order: sell order with stop_price set (for long positions)
-                # Check both string comparison and if stop_price exists
-                if "sell" in side_str and order.get("stop_price"):
-                    stop_price = order["stop_price"]
-                    stop_verified = True
-                    logger.debug(f"  -> Found stop_price: {stop_price}")
-
-                # Take-profit order: sell order with limit_price set (for long positions)
-                elif "sell" in side_str and order.get("limit_price"):
-                    target_price = order["limit_price"]
-                    logger.debug(f"  -> Found target_price: {target_price}")
-        else:
-            logger.debug(f"{symbol}: No orders found in broker_state")
-
-        # If stop not found via API, try to use saved value from local state first
-        # This preserves the actual stop we sent when placing the order
-        if not stop_price and symbol in self.local_state.get("positions", {}):
-            saved_stop = self.local_state["positions"][symbol].get("stop_price")
-            if saved_stop:
-                stop_price = saved_stop
-                logger.info(f"{symbol}: Using saved stop price from local state: ${stop_price}")
-
-        # Last resort: calculate from entry price if we have no saved value
-        # Alpaca hides "held" bracket order legs from get_orders() API
-        if not stop_price and entry_price:
-            # Use strategy config stop_loss percentage
-            stop_loss_pct = self.config.get_risk_config("stop_loss")
-            calculated_stop = round(entry_price * (1 - stop_loss_pct), 2)
-            stop_price = calculated_stop
-            logger.warning(
-                f"{symbol}: Stop order hidden by Alpaca API, no saved value found. "
-                f"Calculated from entry: ${calculated_stop}. "
-                f"Verify actual stop on Alpaca dashboard."
-            )
-
-        logger.info(
-            f"{symbol}: Extracted stop=${stop_price} (verified={stop_verified}), "
-            f"target=${target_price}"
+        # Initialize extracted components
+        self.local_state_manager = LocalStateManager(
+            state_file=state_file,
+            position_tracker=self.position_tracker,
         )
 
-        return stop_price, target_price, stop_verified
+        self.broker_cache = BrokerStateCache(
+            account_monitor=self.account_monitor,
+            check_alerts_callback=self._check_position_alerts_internal,
+            cache_ttl_seconds=60,
+            alert_refresh_interval=300,
+        )
+
+        self.reconciler = StateReconciler(
+            config=self.config,
+            trailing_stop_manager=self.trailing_stop_manager,
+            position_tracker=self.position_tracker,
+        )
+
+        self.report_generator = ReportGenerator()
+
+        logger.info("CostEfficientTradeCycle initialized with extracted components")
+
+    # -------------------------------------------------------------------------
+    # Backward-compatible property accessors
+    # -------------------------------------------------------------------------
+
+    @property
+    def local_state(self) -> Dict[str, Any]:
+        """Get local state dict (backward compatibility)."""
+        return self.local_state_manager.state
+
+    @local_state.setter
+    def local_state(self, value: Dict[str, Any]):
+        """Set local state dict (backward compatibility)."""
+        self.local_state_manager.state = value
+
+    @property
+    def state_file(self) -> str:
+        """Get state file path (backward compatibility)."""
+        return self.local_state_manager.state_file
+
+    # -------------------------------------------------------------------------
+    # Backward-compatible method wrappers
+    # -------------------------------------------------------------------------
+
+    def load_local_state(self) -> Dict[str, Any]:
+        """Load local JSON state (backward compatibility)."""
+        return self.local_state_manager.reload()
+
+    def save_local_state(self):
+        """Save local state to JSON (backward compatibility)."""
+        self.local_state_manager.save()
+
+    def fetch_broker_state(self, force_refresh: bool = False) -> Dict[str, Any]:
+        """Get broker state with caching (backward compatibility)."""
+        return self.broker_cache.fetch(force_refresh)
+
+    def invalidate_broker_cache(self):
+        """Invalidate broker cache (backward compatibility)."""
+        self.broker_cache.invalidate()
+
+    def get_cache_stats(self) -> Dict[str, Any]:
+        """Get cache statistics (backward compatibility)."""
+        return self.broker_cache.get_stats()
+
+    def get_current_alerts(self) -> List[Any]:
+        """Get cached alerts (backward compatibility)."""
+        return self.broker_cache.get_current_alerts()
 
     def reconcile_state(self, broker_state: Dict[str, Any]) -> List[Discrepancy]:
-        """
-        Reconcile local JSON with broker reality.
-        JSON is for humans, broker is truth.
-        """
-        discrepancies = []
-
-        # Check for unknown positions (at broker but not in local JSON)
-        for symbol, broker_pos in broker_state["positions"].items():
-            if symbol not in self.local_state["positions"]:
-                discrepancies.append(
-                    Discrepancy(
-                        type="UNKNOWN_POSITION",
-                        symbol=symbol,
-                        details={
-                            "broker_quantity": broker_pos["quantity"],
-                            "broker_entry": broker_pos["entry_price"],
-                            "current_price": broker_pos["current_price"],
-                        },
-                        action="NEEDS_HUMAN_REVIEW",
-                        severity="HIGH",
-                    )
-                )
-
-                # Extract stop/target prices from broker's open orders
-                entry_price = broker_pos["entry_price"]
-                stop_price, target_price, stop_verified = self._extract_stop_target_from_orders(
-                    symbol, broker_state, entry_price=entry_price
-                )
-
-                # Auto-add to local state for tracking
-                self.local_state["positions"][symbol] = {
-                    "entry_price": broker_pos["entry_price"],
-                    "quantity": broker_pos["quantity"],
-                    "entry_time": now_iso(),
-                    "source": "AUTO_DISCOVERED",
-                    "stop_price": stop_price,
-                    "target_price": target_price,
-                }
-
-        # Check for ghost positions (in local JSON but not at broker)
-        for symbol in list(self.local_state["positions"].keys()):
-            if symbol not in broker_state["positions"]:
-                local_pos = self.local_state["positions"][symbol]
-                discrepancies.append(
-                    Discrepancy(
-                        type="GHOST_POSITION",
-                        symbol=symbol,
-                        details={
-                            "local_quantity": local_pos.get("quantity", 0),
-                            "local_entry": local_pos.get("entry_price", 0),
-                        },
-                        action="REMOVED_FROM_JSON",
-                        severity="MEDIUM",
-                    )
-                )
-
-                # Remove ghost position
-                del self.local_state["positions"][symbol]
-
-        # Check quantity mismatches
-        for symbol in broker_state["positions"]:
-            if symbol in self.local_state["positions"]:
-                broker_qty = broker_state["positions"][symbol]["quantity"]
-                local_qty = self.local_state["positions"][symbol].get("quantity", 0)
-
-                if broker_qty != local_qty:
-                    discrepancies.append(
-                        Discrepancy(
-                            type="QUANTITY_MISMATCH",
-                            symbol=symbol,
-                            details={
-                                "broker_quantity": broker_qty,
-                                "local_quantity": local_qty,
-                                "difference": broker_qty - local_qty,
-                            },
-                            action="AUTO_FIXED",
-                            severity="LOW",
-                        )
-                    )
-
-                    # Fix quantity
-                    self.local_state["positions"][symbol]["quantity"] = broker_qty
-
-        # Sync stop/target prices from broker orders for all positions
-        # This ensures we always have the latest GTC order prices
-        for symbol in broker_state["positions"]:
-            if symbol in self.local_state["positions"]:
-                entry_price = self.local_state["positions"][symbol].get("entry_price")
-                stop_price, target_price, stop_verified = self._extract_stop_target_from_orders(
-                    symbol, broker_state, entry_price=entry_price
-                )
-
-                # Update local state with broker's stop/target prices
-                local_pos = self.local_state["positions"][symbol]
-                local_stop = local_pos.get("stop_price")
-                local_target = local_pos.get("target_price")
-
-                # Only log discrepancy if there was a change
-                if stop_price != local_stop or target_price != local_target:
-                    logger.info(
-                        f"{symbol}: Syncing stop/target from orders - "
-                        f"stop: {local_stop} -> {stop_price}, "
-                        f"target: {local_target} -> {target_price}"
-                    )
-                    local_pos["stop_price"] = stop_price
-                    local_pos["target_price"] = target_price
-
-        logger.info(f"Reconciliation found {len(discrepancies)} discrepancies")
+        """Reconcile state (backward compatibility)."""
+        discrepancies, updated_state = self.reconciler.reconcile(
+            broker_state, self.local_state_manager.state
+        )
+        self.local_state_manager.state = updated_state
         return discrepancies
 
     def calculate_stop_adjustments(self, broker_state: Dict[str, Any]) -> List[StopAdjustment]:
-        """
-        Calculate which stops need adjustment based on current prices.
-
-        Uses TrailingStopManager for progressive stop logic calculation.
-        Broker communication is handled separately by batch_modify_orders().
-        """
-        adjustments = []
-
-        for symbol, broker_pos in broker_state["positions"].items():
-            if symbol not in self.local_state["positions"]:
-                continue  # Skip unknown positions
-
-            local_pos = self.local_state["positions"][symbol]
-            entry_price = float(local_pos.get("entry_price", 0))
-            current_price = broker_pos["current_price"]
-            current_stop = local_pos.get("stop_price")
-            quantity = int(broker_pos.get("quantity", 0))
-
-            if not entry_price or not current_stop:
-                continue  # No entry price or stop to adjust
-
-            # Register position with TrailingStopManager if not already tracked
-            if symbol not in self.trailing_stop_manager.stop_states:
-                self.trailing_stop_manager.register_position(
-                    symbol=symbol,
-                    entry_price=entry_price,
-                    initial_stop=current_stop,
-                    quantity=quantity,
-                    stop_order_id=None,  # We find this separately from broker_state
-                )
-
-            # Use TrailingStopManager to calculate new stop price
-            # This centralizes the progressive stop logic (2%, 4%, 6% thresholds)
-            new_stop = self.trailing_stop_manager.calculate_new_stop(symbol, current_price)
-
-            if new_stop is None:
-                continue  # No adjustment needed
-
-            # Calculate profit percentage for reporting
-            profit_percent = (current_price - entry_price) / entry_price
-
-            # Determine reason based on profit level (for reporting)
-            if profit_percent < 0.04:
-                reason = f"Move to breakeven ({profit_percent:.1%} profit)"
-            elif profit_percent < 0.06:
-                reason = f"Lock 25% gains ({profit_percent:.1%} profit)"
-            else:
-                reason = f"Trail 50% gains ({profit_percent:.1%} profit)"
-
-            logger.info(f"{symbol}: Stop adjustment recommended - {reason}")
-
-            # Only adjust if new stop is higher than current stop
-            if new_stop > current_stop + 0.01:  # $0.01 minimum move
-                # Find the stop order ID from broker orders
-                stop_order_id = None
-                if symbol in broker_state["orders"]:
-                    for order in broker_state["orders"][symbol]:
-                        if order["type"] in ["stop", "stop_loss"] and order["side"] == "sell":
-                            stop_order_id = order["id"]
-                            logger.debug(f"{symbol}: Found stop order ID {stop_order_id}")
-                            break
-
-                if stop_order_id:
-                    adjustment_amount = new_stop - current_stop
-                    adjustment_pct = (adjustment_amount / current_stop) * 100
-                    logger.info(
-                        f"{symbol}: Creating stop adjustment - "
-                        f"${current_stop:.2f} → ${new_stop:.2f} "
-                        f"(+${adjustment_amount:.2f}, +{adjustment_pct:.1f}%)"
-                    )
-
-                    adjustments.append(
-                        StopAdjustment(
-                            symbol=symbol,
-                            order_id=stop_order_id,
-                            current_stop=current_stop,
-                            new_stop=new_stop,
-                            reason=reason,
-                            profit_percent=profit_percent,
-                        )
-                    )
-
-                    # Update local state
-                    self.local_state["positions"][symbol]["stop_price"] = new_stop
-
-                    # Update TrailingStopManager state to stay in sync
-                    if symbol in self.trailing_stop_manager.stop_states:
-                        self.trailing_stop_manager.stop_states[symbol].current_stop = new_stop
-                else:
-                    logger.warning(
-                        f"{symbol}: Stop adjustment needed but no stop order found in broker orders"
-                    )
-            else:
-                logger.debug(
-                    f"{symbol}: New stop ${new_stop:.2f} not significantly higher "
-                    f"than current ${current_stop:.2f}"
-                )
-
-        logger.info(f"Found {len(adjustments)} stop adjustments needed")
+        """Calculate stop adjustments (backward compatibility)."""
+        adjustments, updated_state = self.reconciler.calculate_stop_adjustments(
+            broker_state, self.local_state_manager.state
+        )
+        self.local_state_manager.state = updated_state
         return adjustments
 
     def check_position_alerts(self, broker_state: Dict[str, Any]) -> List[PositionAlertSummary]:
-        """
-        Check all positions for exit alerts (approaching TP/SL).
+        """Check position alerts (backward compatibility)."""
+        return self.reconciler.check_position_alerts(broker_state, self.local_state_manager.state)
 
-        Args:
-            broker_state: Current broker state with positions
+    def _check_position_alerts_internal(self, broker_state: Dict[str, Any]) -> List[Any]:
+        """Internal callback for broker cache alert refresh."""
+        return self.reconciler.check_position_alerts(broker_state, self.local_state_manager.state)
 
-        Returns:
-            List of position alerts
-        """
-        alerts = []
+    def generate_position_summaries(
+        self, broker_state: Dict[str, Any], adjustments: List[StopAdjustment]
+    ) -> List[Any]:
+        """Generate position summaries (backward compatibility)."""
+        return self.report_generator.generate_position_summaries(
+            broker_state, self.local_state_manager.state, adjustments
+        )
 
-        for symbol, broker_pos in broker_state["positions"].items():
-            if symbol not in self.local_state["positions"]:
-                continue  # Skip unknown positions
+    def generate_routine_report(
+        self,
+        routine_type: RoutineType,
+        broker_state: Dict[str, Any],
+        discrepancies: List[Discrepancy],
+        adjustments: List[StopAdjustment],
+        alerts: List[PositionAlertSummary] = None,
+        modification_results: Dict[str, Any] = None,
+    ) -> str:
+        """Generate trading report (backward compatibility)."""
+        return self.report_generator.generate_routine_report(
+            routine_type,
+            broker_state,
+            self.local_state_manager.state,
+            discrepancies,
+            adjustments,
+            alerts,
+            modification_results,
+        )
 
-            local_pos = self.local_state["positions"][symbol]
-            entry_price = float(local_pos.get("entry_price", 0))
-            current_price = broker_pos["current_price"]
-            take_profit_price = local_pos.get("target_price")
-            stop_loss_price = local_pos.get("stop_price")
-
-            if not entry_price or not take_profit_price or not stop_loss_price:
-                continue  # Skip positions without complete data
-
-            # Create or update position in tracker
-            position_id = f"{symbol}_{entry_price}"
-            try:
-                if position_id not in self.position_tracker.positions:
-                    # Create position for tracking
-                    self.position_tracker.create_position(
-                        ticker=symbol, entry_price=entry_price, quantity=broker_pos["quantity"]
-                    )
-                    # Manually set TP/SL prices to match configured values
-                    if position_id in self.position_tracker.positions:
-                        position = self.position_tracker.positions[position_id]
-                        position.take_profit_price = take_profit_price
-                        position.stop_loss_price = stop_loss_price
-
-                # Check for exit conditions/alerts
-                exit_check = self.position_tracker.check_exit_conditions(position_id, current_price)
-
-                if exit_check and exit_check.get("recommendation") == "ALERT":
-                    # Get the most recent alert for this position
-                    if position_id in self.position_tracker.positions:
-                        position = self.position_tracker.positions[position_id]
-                        if position.alert_history:
-                            recent_alert = position.alert_history[-1]
-                            alerts.append(
-                                PositionAlertSummary(
-                                    symbol=symbol,
-                                    alert_type=recent_alert.alert_type.value,
-                                    severity=recent_alert.severity,
-                                    message=recent_alert.format_message(),
-                                    timestamp=recent_alert.timestamp.isoformat(),
-                                    current_price=current_price,
-                                    details=recent_alert.details,
-                                )
-                            )
-            except (KeyError, Exception) as e:
-                logger.warning(f"Position tracker error for {symbol}: {e}")
-
-        logger.info(f"Found {len(alerts)} position alerts")
-        return alerts
+    # -------------------------------------------------------------------------
+    # Order execution (kept in main class as it handles broker communication)
+    # -------------------------------------------------------------------------
 
     def batch_modify_orders(self, adjustments: List[StopAdjustment]) -> Dict[str, Any]:
         """
@@ -800,9 +264,12 @@ class CostEfficientTradeCycle:
 
                 if success:
                     results["modifications"] += 1
-                    profit_locked = adjustment.new_stop - float(
-                        self.local_state["positions"][adjustment.symbol].get("entry_price", 0)
+                    entry_price = (
+                        self.local_state_manager.state.get("positions", {})
+                        .get(adjustment.symbol, {})
+                        .get("entry_price", 0)
                     )
+                    profit_locked = adjustment.new_stop - float(entry_price)
                     detail_msg = (
                         f"✅ {adjustment.symbol}: Stop adjusted to ${adjustment.new_stop:.2f} "
                         f"(locking ${profit_locked:+.2f} profit)"
@@ -829,184 +296,15 @@ class CostEfficientTradeCycle:
         )
         logger.info(summary)
 
-        # Issue #337: Invalidate cache after modifying orders
+        # Invalidate cache after modifying orders
         if results["modifications"] > 0:
-            self.invalidate_broker_cache()
+            self.broker_cache.invalidate()
 
         return results
 
-    def generate_position_summaries(
-        self, broker_state: Dict[str, Any], adjustments: List[StopAdjustment]
-    ) -> List[PositionSummary]:
-        """Generate position summaries for reporting"""
-        summaries = []
-
-        # Create adjustment lookup
-        adjustment_map = {adj.symbol: adj for adj in adjustments}
-
-        for symbol, broker_pos in broker_state["positions"].items():
-            if symbol not in self.local_state["positions"]:
-                continue
-
-            local_pos = self.local_state["positions"][symbol]
-            current_price = float(broker_pos.get("current_price") or 0)
-            entry_price = float(local_pos.get("entry_price") or 0)
-            quantity = int(broker_pos.get("quantity") or 0)
-
-            # Calculate P&L
-            unrealized_pl = (current_price - entry_price) * quantity
-            unrealized_percent = ((current_price - entry_price) / entry_price) if entry_price else 0
-
-            # Determine stop action
-            stop_action = "No change"
-            if symbol in adjustment_map:
-                stop_action = adjustment_map[symbol].reason
-
-            summaries.append(
-                PositionSummary(
-                    symbol=symbol,
-                    entry_price=entry_price,
-                    current_price=current_price,
-                    stop_price=float(local_pos.get("stop_price") or 0),
-                    target_price=float(local_pos.get("target_price") or 0),
-                    quantity=quantity,
-                    unrealized_pl=unrealized_pl,
-                    unrealized_percent=unrealized_percent,
-                    stop_action=stop_action,
-                )
-            )
-
-        return summaries
-
-    def generate_routine_report(
-        self,
-        routine_type: RoutineType,
-        broker_state: Dict[str, Any],
-        discrepancies: List[Discrepancy],
-        adjustments: List[StopAdjustment],
-        alerts: List[PositionAlertSummary] = None,
-        modification_results: Dict[str, Any] = None,
-    ) -> str:
-        """Generate human-readable trading report with alerts"""
-
-        now = get_datetime_now()
-        report_lines = [
-            f"# {routine_type.value.title()} Trading Report - {now.strftime('%Y-%m-%d %H:%M:%S')}",
-            "",
-        ]
-
-        # Account summary
-        account = broker_state.get("account", {})
-        portfolio_value = float(account.get("portfolio_value") or 0)
-        cash = float(account.get("cash") or 0)
-        buying_power = float(account.get("buying_power") or 0)
-
-        report_lines.extend(
-            [
-                "## Account Summary",
-                f"Portfolio Value: ${portfolio_value:,.2f}",
-                f"Available Cash: ${cash:,.2f}",
-                f"Buying Power: ${buying_power:,.2f}",
-                "",
-            ]
-        )
-
-        # Position summaries
-        summaries = self.generate_position_summaries(broker_state, adjustments)
-        if summaries:
-            report_lines.extend(
-                [
-                    "## Active Positions",
-                    "| Symbol | Entry | Current | Stop | Target | P&L | Action |",
-                    "|--------|-------|---------|------|--------|-----|--------|",
-                ]
-            )
-
-            for summary in summaries:
-                pl_sign = "+" if summary.unrealized_pl >= 0 else ""
-                pl_str = f"{pl_sign}${summary.unrealized_pl:.0f} ({summary.unrealized_percent:.1%})"
-                report_lines.append(
-                    f"| {summary.symbol} | ${summary.entry_price:.2f} | "
-                    f"${summary.current_price:.2f} | ${summary.stop_price:.2f} | "
-                    f"${summary.target_price:.2f} | {pl_str} | {summary.stop_action} |"
-                )
-            report_lines.append("")
-        else:
-            report_lines.extend(["## Active Positions", "No active positions", ""])
-
-        # Discrepancies
-        if discrepancies:
-            report_lines.extend(["## Discrepancies Found"])
-            for disc in discrepancies:
-                severity_emoji = {"HIGH": "🚨", "MEDIUM": "⚠️", "LOW": "ℹ️"}[disc.severity]
-                report_lines.append(f"{severity_emoji} {disc.type}: {disc.symbol}")
-
-                if disc.type == "UNKNOWN_POSITION":
-                    qty = disc.details["broker_quantity"]
-                    entry = disc.details["broker_entry"]
-                    report_lines.append(f"   {qty} shares at ${entry:.2f} - {disc.action}")
-                elif disc.type == "GHOST_POSITION":
-                    qty = disc.details["local_quantity"]
-                    report_lines.append(f"   Phantom {qty} shares - {disc.action}")
-                elif disc.type == "QUANTITY_MISMATCH":
-                    broker_qty = disc.details["broker_quantity"]
-                    local_qty = disc.details["local_quantity"]
-                    report_lines.append(
-                        f"   Broker: {broker_qty}, Local: {local_qty} - {disc.action}"
-                    )
-
-                report_lines.append("")
-
-        # Position Alerts
-        if alerts:
-            report_lines.extend(["## Position Alerts"])
-            # Count by severity
-            critical_count = len([a for a in alerts if a.severity == "CRITICAL"])
-            warning_count = len([a for a in alerts if a.severity == "WARNING"])
-            info_count = len([a for a in alerts if a.severity == "INFO"])
-
-            report_lines.append(
-                f"Total Alerts: {len(alerts)} "
-                f"({critical_count} Critical, {warning_count} Warning, {info_count} Info)"
-            )
-            report_lines.append("")
-
-            for alert in alerts:
-                report_lines.append(alert.message)
-
-            report_lines.append("")
-
-        # Stop modifications
-        if modification_results:
-            report_lines.extend(["## Stop Adjustments"])
-            if modification_results["modifications"] > 0:
-                report_lines.append(
-                    f"✅ {modification_results['modifications']} stops adjusted successfully"
-                )
-
-            if modification_results["errors"]:
-                report_lines.append("❌ Errors:")
-                for error in modification_results["errors"]:
-                    report_lines.append(f"   {error}")
-            report_lines.append("")
-
-        # Footer
-        next_routine = "evening" if routine_type == RoutineType.MORNING else "morning"
-        next_time = "15:50:00" if routine_type == RoutineType.MORNING else "09:20:00"
-        report_lines.extend(
-            [
-                "---",
-                f"Generated: {now.strftime('%Y-%m-%d %H:%M:%S')}",
-                f"Next {next_routine} routine: {next_time}",
-                "Cost: ~3-5 API calls total",
-                "",
-                "**Note**: Stop prices calculated from entry price "
-                "(Alpaca hides bracket order stop-loss legs from API).",
-                "Verify stop orders exist on Alpaca dashboard. See Issue #355.",
-            ]
-        )
-
-        return "\n".join(report_lines)
+    # -------------------------------------------------------------------------
+    # Trading routines
+    # -------------------------------------------------------------------------
 
     def morning_routine(self) -> str:
         """
@@ -1034,8 +332,8 @@ class CostEfficientTradeCycle:
                 modification_results = self.batch_modify_orders(adjustments)
 
             # Step 6: Save updated local state
-            self.local_state["discrepancies"] = [asdict(d) for d in discrepancies]
-            self.save_local_state()
+            self.local_state_manager.state["discrepancies"] = [asdict(d) for d in discrepancies]
+            self.local_state_manager.save()
 
             # Step 7: Generate human report with alerts
             report = self.generate_routine_report(
@@ -1047,24 +345,8 @@ class CostEfficientTradeCycle:
                 modification_results,
             )
 
-            # Save report to file with human-readable format: 2025-11-11_morning.md
-            # If multiple runs same day, append counter: morning_2.md, morning_3.md
-            now = get_datetime_now()
-            date_str = now.strftime("%Y-%m-%d")
-
-            # Get report path template from config
-            template = self.paths.get("report_templates", {}).get(
-                "daily_routine", "reports/daily/{date}_{routine_type}.md"
-            )
-            base_name = template.format(date=date_str, routine_type="morning").replace(".md", "")
-
-            # Check for existing files and append counter if needed
-            report_file = f"{base_name}.md"
-            counter = 1
-            while os.path.exists(report_file):
-                counter += 1
-                report_file = f"{base_name}_{counter}.md"
-
+            # Save report to file
+            report_file = self._get_report_file_path("morning")
             os.makedirs(os.path.dirname(report_file), exist_ok=True)
             with open(report_file, "w", encoding="utf-8") as f:
                 f.write(report)
@@ -1092,33 +374,14 @@ class CostEfficientTradeCycle:
             # Check for position alerts
             alerts = self.check_position_alerts(broker_state)
 
-            # Evening-specific: Check for positions that might need closing
-            # (This is where we might add EOD logic later)
-
-            self.save_local_state()
+            self.local_state_manager.save()
 
             report = self.generate_routine_report(
                 RoutineType.EVENING, broker_state, discrepancies, [], alerts
             )
 
-            # Save report to file with human-readable format: 2025-11-11_evening.md
-            # If multiple runs same day, append counter: evening_2.md, evening_3.md
-            now = get_datetime_now()
-            date_str = now.strftime("%Y-%m-%d")
-
-            # Get report path template from config
-            template = self.paths.get("report_templates", {}).get(
-                "daily_routine", "reports/daily/{date}_{routine_type}.md"
-            )
-            base_name = template.format(date=date_str, routine_type="evening").replace(".md", "")
-
-            # Check for existing files and append counter if needed
-            report_file = f"{base_name}.md"
-            counter = 1
-            while os.path.exists(report_file):
-                counter += 1
-                report_file = f"{base_name}_{counter}.md"
-
+            # Save report to file
+            report_file = self._get_report_file_path("evening")
             os.makedirs(os.path.dirname(report_file), exist_ok=True)
             with open(report_file, "w", encoding="utf-8") as f:
                 f.write(report)
@@ -1142,26 +405,24 @@ class CostEfficientTradeCycle:
             # One API call to get everything
             broker_state = self.fetch_broker_state()
 
-            # Rebuild local state from broker truth
-            self.local_state = {
-                "positions": {},
-                "last_update": now_iso(),
-                "discrepancies": [],
-                "recovery_timestamp": now_iso(),
-            }
+            # Reset local state for recovery
+            self.local_state_manager.reset_for_recovery()
 
             # Auto-discover all positions
             for symbol, broker_pos in broker_state["positions"].items():
-                self.local_state["positions"][symbol] = {
-                    "entry_price": broker_pos["entry_price"],
-                    "quantity": broker_pos["quantity"],
-                    "entry_time": "UNKNOWN",
-                    "source": "CRASH_RECOVERY",
-                    "stop_price": None,  # Will need human input
-                    "target_price": None,  # Will need human input
-                }
+                self.local_state_manager.set_position(
+                    symbol,
+                    {
+                        "entry_price": broker_pos["entry_price"],
+                        "quantity": broker_pos["quantity"],
+                        "entry_time": "UNKNOWN",
+                        "source": "CRASH_RECOVERY",
+                        "stop_price": None,  # Will need human input
+                        "target_price": None,  # Will need human input
+                    },
+                )
 
-            self.save_local_state()
+            self.local_state_manager.save()
 
             # Generate recovery report
             recovery_lines = [
@@ -1173,7 +434,7 @@ class CostEfficientTradeCycle:
                 "## Recovered Positions",
             ]
 
-            for symbol, pos in self.local_state["positions"].items():
+            for symbol, pos in self.local_state_manager.positions.items():
                 recovery_lines.append(
                     f"- {symbol}: {pos['quantity']} shares @ ${pos['entry_price']:.2f}"
                 )
@@ -1191,24 +452,8 @@ class CostEfficientTradeCycle:
 
             report = "\n".join(recovery_lines)
 
-            # Save recovery report with human-readable format: 2025-11-11_recovery.md
-            # Recovery is ad-hoc, so include counter for multiple recoveries same day
-            now = get_datetime_now()
-            date_str = now.strftime("%Y-%m-%d")
-
-            # Get report path template from config
-            template = self.paths.get("report_templates", {}).get(
-                "daily_routine", "reports/daily/{date}_{routine_type}.md"
-            )
-            base_name = template.format(date=date_str, routine_type="recovery").replace(".md", "")
-
-            # Check for existing files and append counter if needed
-            report_file = f"{base_name}.md"
-            counter = 1
-            while os.path.exists(report_file):
-                counter += 1
-                report_file = f"{base_name}_{counter}.md"
-
+            # Save recovery report
+            report_file = self._get_report_file_path("recovery")
             os.makedirs(os.path.dirname(report_file), exist_ok=True)
             with open(report_file, "w", encoding="utf-8") as f:
                 f.write(report)
@@ -1220,6 +465,25 @@ class CostEfficientTradeCycle:
             error_msg = f"Crash recovery failed: {e}"
             logger.error(error_msg)
             return f"❌ {error_msg}"
+
+    def _get_report_file_path(self, routine_type: str) -> str:
+        """Get unique report file path with counter for multiple runs per day."""
+        now = get_datetime_now()
+        date_str = now.strftime("%Y-%m-%d")
+
+        template = self.paths.get("report_templates", {}).get(
+            "daily_routine", "reports/daily/{date}_{routine_type}.md"
+        )
+        base_name = template.format(date=date_str, routine_type=routine_type).replace(".md", "")
+
+        # Check for existing files and append counter if needed
+        report_file = f"{base_name}.md"
+        counter = 1
+        while os.path.exists(report_file):
+            counter += 1
+            report_file = f"{base_name}_{counter}.md"
+
+        return report_file
 
 
 def main():


### PR DESCRIPTION
## Summary

Refactors `trading_cycle.py` (1248 lines) into modular components for improved maintainability:

- **LocalStateManager** - JSON state persistence (140 lines)
- **BrokerStateCache** - Cached broker state with TTL (278 lines)
- **StateReconciler** - Reconciliation logic, stop adjustments, alerts (475 lines)
- **ReportGenerator** - Human-readable report formatting (251 lines)

**Result:** trading_cycle.py reduced from 1248 to 510 lines (**59% reduction**)

### Changes
- Extracted 4 focused components from monolithic class
- Maintained backward compatibility via property accessors and method wrappers
- All existing public methods still work identically
- Components can now be unit tested independently

### Closes #439

## Test plan
- [ ] Verify `python main.py morning` still generates reports
- [ ] Verify `python main.py evening` still generates reports  
- [ ] Verify state persistence across restarts
- [ ] Run existing unit tests