### PR TITLE
fix: Make 'timeframe' command show full list like 'list timeframe'

### DIFF
--- a/src/cli/cli_session.py
+++ b/src/cli/cli_session.py
@@ -1559,6 +1559,6 @@ Scope: Only resolve to real, tradable companies. Return found=false for ambiguou
             safe_print(output)
 
         else:
-            # Default: show current timeframe
-            output = tf_commands.show_current_timeframe()
+            # Default: show full list with current highlighted (Issue #470)
+            output = tf_commands.list_timeframes(verbose=True)
             safe_print(output)


### PR DESCRIPTION
## Summary
Closes #470

Changes the behavior of the `timeframe` command to show the full list of available timeframes with the current one highlighted, instead of only showing the current timeframe.

## Changes
- Modified `src/cli/cli_session.py` line 1563
- Changed from `show_current_timeframe()` to `list_timeframes(verbose=True)`

## Before
```
> timeframe
📍 Current Timeframe
==================================================
  1D: 1 day bars
```

## After
```
> timeframe
📊 Available Timeframes:
==================================================
  [✓] 1D    - 1 day bars
  [ ] 1H    - 1 hour bars
  [ ] 1M    - 1 month bars
  ...

--------------------------------------------------
📍 Current: 1D
```

## Benefits
- Better UX - users see all options when checking timeframe
- Easier to discover available timeframes
- Consistent with `list timeframe` behavior

## Testing
- [x] Syntax validated
- [x] Pre-commit hooks passed (C901 warnings pre-existing)
- [x] Single line change, low risk